### PR TITLE
add namespace macros

### DIFF
--- a/src/async.cc
+++ b/src/async.cc
@@ -10,7 +10,7 @@
 #include "async.h"
 #include "batch.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 /** ASYNC BASE **/
 
@@ -67,4 +67,4 @@ void AsyncQueueWorker (AsyncWorker* worker) {
   );
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/async.h
+++ b/src/async.h
@@ -8,7 +8,7 @@
 
 #include <node.h>
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 /* abstract */ class AsyncWorker {
 public:
@@ -34,6 +34,6 @@ void AsyncExecute (uv_work_t* req);
 void AsyncExecuteComplete (uv_work_t* req);
 void AsyncQueueWorker (AsyncWorker* worker);
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -7,7 +7,7 @@
 
 #include "batch.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 BatchOp::~BatchOp () {}
 
@@ -28,4 +28,4 @@ void BatchWrite::Execute (leveldb::WriteBatch* batch) {
   batch->Put(key, value);
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/batch.h
+++ b/src/batch.h
@@ -10,7 +10,7 @@
 
 #include "database.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 class BatchOp {
 public:
@@ -57,6 +57,6 @@ private:
   v8::Persistent<v8::Value> valuePtr;
 };
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/database.cc
+++ b/src/database.cc
@@ -16,7 +16,7 @@
 #include "batch.h"
 #include "iterator.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 Database::Database (char* location) : location(location) {
   db = NULL;
@@ -410,4 +410,4 @@ v8::Handle<v8::Value> Database::Iterator (const v8::Arguments& args) {
   return scope.Close(Iterator::NewInstance(args.This(), optionsObj));
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/database.h
+++ b/src/database.h
@@ -12,7 +12,7 @@
 
 #include "leveldown.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 LU_SYMBOL ( option_createIfMissing , createIfMissing ); // for open()
 LU_SYMBOL ( option_errorIfExists   , errorIfExists   ); // for open()
@@ -77,6 +77,6 @@ private:
   LU_V8_METHOD( ApproximateSize )
 };
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -12,7 +12,7 @@
 #include "database_async.h"
 #include "batch.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 /** OPEN WORKER **/
 
@@ -235,4 +235,4 @@ void ApproximateSizeWorker::HandleOKCallback () {
   RUN_CALLBACK(callback, argv, 2);
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/database_async.h
+++ b/src/database_async.h
@@ -14,7 +14,7 @@
 #include "async.h"
 #include "batch.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 class OpenWorker : public AsyncWorker {
 public:
@@ -162,6 +162,6 @@ public:
     uint64_t size;
 };
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -10,7 +10,7 @@
 #include "iterator.h"
 #include "iterator_async.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 Iterator::Iterator (
     Database* database
@@ -278,4 +278,4 @@ v8::Handle<v8::Value> Iterator::New (const v8::Arguments& args) {
   return args.This();
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -12,7 +12,7 @@
 #include "database.h"
 #include "async.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 LU_SYMBOL ( option_start         , start         );
 LU_SYMBOL ( option_end           , end           );
@@ -84,6 +84,6 @@ private:
   LU_V8_METHOD( End  )
 };
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/iterator_async.cc
+++ b/src/iterator_async.cc
@@ -11,7 +11,7 @@
 #include "async.h"
 #include "iterator_async.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 /** NEXT WORKER **/
 
@@ -82,4 +82,4 @@ void EndWorker::Execute () {
   iterator->IteratorEnd();
 }
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/iterator_async.h
+++ b/src/iterator_async.h
@@ -11,7 +11,7 @@
 #include "async.h"
 #include "iterator.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 class NextWorker : public AsyncWorker {
 public:
@@ -47,6 +47,6 @@ private:
   Iterator* iterator;
 };
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)
 
 #endif

--- a/src/leveldown.cc
+++ b/src/leveldown.cc
@@ -9,7 +9,7 @@
 #include "database.h"
 #include "iterator.h"
 
-namespace leveldown {
+BEGIN_NAMESPACE(leveldown)
 
 void Init (v8::Handle<v8::Object> target) {
   Database::Init();
@@ -21,4 +21,4 @@ void Init (v8::Handle<v8::Object> target) {
 
 NODE_MODULE(leveldown, Init)
 
-} // namespace leveldown
+END_NAMESPACE(leveldown)

--- a/src/leveldown.h
+++ b/src/leveldown.h
@@ -129,4 +129,8 @@
 
 #define METHOD_SETUP_COMMON_ONEARG(name) METHOD_SETUP_COMMON(name, -1, 0)
 
+#define BEGIN_NAMESPACE(name) namespace name {
+
+#define END_NAMESPACE(name) }
+
 #endif


### PR DESCRIPTION
Hope you don't mind this change. This is purely for selfish reasons. By using these macros and the pre-processor I can fool my editor that there isn't any extra scope -> No extra level of indentation for the code within the namespace block!

I also think it's better with self documenting code

``` c++
END_NAMESPACE(leveldown)
```

instead of commenting the code like this:

``` c++
} // namespace leveldown
```
