### PR TITLE
Now builds on smartos with some arcane gyp flag added.

### DIFF
--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -4,6 +4,8 @@
         'ldbversion': '1.9.0'
     }
   , 'type': 'static_library'
+		# Overcomes an issue with the linker and thin .a files on SmartOS
+  , 'standalone_static_library': 1
   , 'dependencies': [
         '../snappy/snappy.gyp:snappy'
     ]

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -9,6 +9,8 @@
     }
   , 'target_name': 'snappy'
   , 'type': 'static_library'
+		# Overcomes an issue with the linker and thin .a files on SmartOS
+  , 'standalone_static_library': 1
   , 'include_dirs': [
         '<(os_include)'
       , 'snappy-1.1.0'


### PR DESCRIPTION
After digging around and with the help of @TooTallNate I got it building on SmartOS.

Currently on SmartOS a thin .a file is being built by `ar` which requires different flags to be passed to the linker. 

According to @TooTallNate setting `standalone_static_library` to 1 removes -T switch passed to the linker which stops it from bombing out with an error.
