### PR TITLE
use more efficient emptiness checking

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -104,7 +104,7 @@ void Database::ReleaseIterator (uint32_t id) {
   // if there is a pending CloseWorker it means that we're waiting for
   // iterators to end before we can close them
   iterators.erase(id);
-  if (iterators.size() == 0 && pendingCloseWorker != NULL) {
+  if (iterators.empty() && pendingCloseWorker != NULL) {
     AsyncQueueWorker((AsyncWorker*)pendingCloseWorker);
     pendingCloseWorker = NULL;
   }
@@ -276,7 +276,7 @@ v8::Handle<v8::Value> Database::Close (const v8::Arguments& args) {
     , v8::Persistent<v8::Function>::New(LD_NODE_ISOLATE_PRE callback)
   );
 
-  if (database->iterators.size() > 0) {
+  if (!database->iterators.empty()) {
     // yikes, we still have iterators open! naughty naughty.
     // we have to queue up a CloseWorker and manually close each of them.
     // the CloseWorker will be invoked once they are all cleaned up


### PR DESCRIPTION
Using empty() instead of size() can be faster. size() can take linear time but empty() is guaranteed to take constant time.

Issue(s) found via [cppcheck](http://cppcheck.sourceforge.net/).
