### PR TITLE
Experimental: Use batch for put() & del()-operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var binding = require('bindings')('leveldown.node').leveldown
 
   , util = require('util')
 
+  , extend = require('xtend')
   , AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
 
   , ChainedBatch = require('./lib/chained-batch')
@@ -43,11 +44,22 @@ var binding = require('bindings')('leveldown.node').leveldown
     }
 
   , _put = function(key, value, options, callback) {
-      this._binding.put(key, value, options, callback)
+      var batch = extend(options, {
+          type: 'put'
+        , key: key
+        , value: value
+      })
+
+      this.batch([batch], callback)
     }
 
   , _del = function(key, options, callback) {
-      this._binding.del(key, options, callback)
+      var batch = extend(options, {
+          type: 'del'
+        , key: key
+      })
+
+      this.batch([batch], callback)
     }
 
   , _iterator = function(options) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   , "dependencies"    : {
         "bindings"            : "~1.1.1"
       , "abstract-leveldown"  : "~0.9.0"
+      , "xtend"               : "~2.0.6"
     }
   , "devDependencies" : {
         "tap"                 : "~0.4.1"


### PR DESCRIPTION
As @dominictarr suggested in https://github.com/rvagg/node-levelup/issues/164, but for leveldown only. 

I have not yet done any benchmarks for this, so performance my hurt. Also it's built upon #50, so it's a little bit unstable.
