### PR TITLE
[discussion] first pass at a multiget

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -137,6 +137,7 @@ void Database::Init () {
   NODE_SET_PROTOTYPE_METHOD(tpl, "close", Database::Close);
   NODE_SET_PROTOTYPE_METHOD(tpl, "put", Database::Put);
   NODE_SET_PROTOTYPE_METHOD(tpl, "get", Database::Get);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "multiget", Database::MultiGet);
   NODE_SET_PROTOTYPE_METHOD(tpl, "del", Database::Delete);
   NODE_SET_PROTOTYPE_METHOD(tpl, "batch", Database::Batch);
   NODE_SET_PROTOTYPE_METHOD(tpl, "approximateSize", Database::ApproximateSize);
@@ -345,6 +346,36 @@ NAN_METHOD(Database::Get) {
     , keyHandle
   );
   NanAsyncQueueWorker(worker);
+
+  NanReturnUndefined();
+}
+
+NAN_METHOD(Database::MultiGet) {
+  NanScope();
+
+  LD_METHOD_SETUP_COMMON(multiget, 1, 2)
+
+  LD_CB_ERR_IF_NULL_OR_UNDEFINED(args[0], keys)
+
+  v8::Local<v8::Array> keys = args[0].As<v8::Array>();
+
+  bool asBuffer = NanBooleanOptionValue(optionsObj, NanSymbol("asBuffer"), true);
+  bool fillCache = NanBooleanOptionValue(optionsObj, NanSymbol("fillCache"), true);
+
+  for (unsigned int i = 0; i < keys->Length(); i++) {
+    v8::Local<v8::Object> keyHandle = v8::Local<v8::Object>::Cast(keys->Get(i));
+    LD_STRING_OR_BUFFER_TO_SLICE(key, keyHandle, key)
+
+    ReadWorker* worker = new ReadWorker(
+        database
+      , new NanCallback(callback)
+      , key
+      , asBuffer
+      , fillCache
+      , keyHandle
+    );
+    NanAsyncQueueWorker(worker);
+  }
 
   NanReturnUndefined();
 }

--- a/src/database.h
+++ b/src/database.h
@@ -93,6 +93,7 @@ private:
   static NAN_METHOD(Put);
   static NAN_METHOD(Delete);
   static NAN_METHOD(Get);
+  static NAN_METHOD(MultiGet);
   static NAN_METHOD(Batch);
   static NAN_METHOD(Write);
   static NAN_METHOD(Iterator);

--- a/test/multiget-test.js
+++ b/test/multiget-test.js
@@ -1,0 +1,7 @@
+const test       = require('tap').test
+    , testCommon = require('abstract-leveldown/testCommon')
+    , leveldown  = require('../')
+    , abstract   = require('abstract-leveldown/abstract/multiget-test')
+
+if (require.main === module)
+  abstract.all(leveldown, test, testCommon)


### PR DESCRIPTION
this is a discussion pull request.

i've added `multiget`, which accepts an array of id's to retrieve, and operates similar to `get`.  for each key, a `ReadWorker` is queued.  on each `get`, the callback is fired with either an error if a key is not found, or the record.

there may be bugs (likely are, my c++ is rusty, and the last time i wrote against v8 was node v0.4.x), and there may be a better way to do this - hence the discussion.

against 620,350 records requested, the speed difference is about 20% faster.  the speedup comes from needing to cross the `v8 <-> c++ <-> v8` boundary less times.  with `get`, there are 620,350 requests, and 620,350 callbacks, resulting in 1,240,700 crossings of the boundary.  `multiget` reduces this to 620,351.

here's the script test with `multiget`:

```
var leveldown = require('./index');

var db = leveldown('../data/buildings');
var indexes = require('../data/indexes.json');
var count = 0;
db.open(function () {
  console.log(arguments);
  var start = +new Date();
  db.multiget(indexes, function () {
    count++;

    if (count === indexes.length) {
      var end = +new Date();
      console.log('done!', end - start, count);
    }
  });

});
```

and the same with `get`:

```

var leveldown = require('./index');

var db = leveldown('../data/buildings'),
    indexes = require('../data/indexes.json'),
    count = 0, i;
db.open(function () {
  console.log(arguments);
  var start = +new Date();
  for (i = 0; i < indexes.length; i++) {
    db.get(indexes[i], function () {
      count++;

      if (count === indexes.length) {
        var end = +new Date();
        console.log('done!', end - start);
      }
    });
  }

});
```


thoughts?
