### PR TITLE
Persistent handles not needed for batch

### DIFF
--- a/src/batch.cc
+++ b/src/batch.cc
@@ -100,8 +100,8 @@ NAN_METHOD(Batch::Put) {
   LD_STRING_OR_BUFFER_TO_SLICE(key, keyBuffer, key)
   LD_STRING_OR_BUFFER_TO_SLICE(value, valueBuffer, value)
 
-  batch->references->push_back(new Reference(keyBuffer, key));
-  batch->references->push_back(new Reference(valueBuffer, value));
+  //batch->references->push_back(new Reference(keyBuffer, key));
+  //batch->references->push_back(new Reference(valueBuffer, value));
 
   batch->batch->Put(key, value);
   if (!batch->hasData)
@@ -125,7 +125,7 @@ NAN_METHOD(Batch::Del) {
   v8::Local<v8::Value> keyBuffer = args[0];
   LD_STRING_OR_BUFFER_TO_SLICE(key, keyBuffer, key)
 
-  batch->references->push_back(new Reference(keyBuffer, key));
+  //batch->references->push_back(new Reference(keyBuffer, key));
 
   batch->batch->Delete(key);
   if (!batch->hasData)

--- a/src/database.cc
+++ b/src/database.cc
@@ -412,7 +412,7 @@ NAN_METHOD(Database::Batch) {
       if (!hasData)
         hasData = true;
 
-      references->push_back(new Reference(keyBuffer, key));
+      //references->push_back(new Reference(keyBuffer, key));
     } else if (obj->Get(NanSymbol("type"))->StrictEquals(NanSymbol("put"))) {
       v8::Local<v8::Value> valueBuffer = obj->Get(NanSymbol("value"));
       LD_CB_ERR_IF_NULL_OR_UNDEFINED(valueBuffer, value)
@@ -424,8 +424,8 @@ NAN_METHOD(Database::Batch) {
       if (!hasData)
         hasData = true;
 
-      references->push_back(new Reference(keyBuffer, key));
-      references->push_back(new Reference(valueBuffer, value));
+      //references->push_back(new Reference(keyBuffer, key));
+      //references->push_back(new Reference(valueBuffer, value));
     }
   }
 


### PR DESCRIPTION
I'm debugging for https://github.com/rvagg/node-levelup/issues/171 and I found out something weird: persistent handles might not be needed for batches. This reduces the memory footprint for batches.

In order to add a put to a batch we call `batch->put`, like this: https://github.com/rvagg/node-leveldown/blob/master/src/batch.cc#L125-L128.
This is the content of `batch->put` (
https://github.com/rvagg/node-leveldown/blob/master/deps/leveldb/leveldb-1.14.0/db/write_batch.cc#L98-L103):

```
void WriteBatch::Put(const Slice& key, const Slice& value) {
  WriteBatchInternal::SetCount(this, WriteBatchInternal::Count(this) + 1);
  rep_.push_back(static_cast<char>(kTypeValue));
  PutLengthPrefixedSlice(&rep_, key);
  PutLengthPrefixedSlice(&rep_, value);
}
```

In `batch->put`, `rep_` is a `std::string`.

You can find `PutLengthPrefixedSlice` at: https://github.com/rvagg/node-leveldown/blob/master/deps/leveldb/leveldb-1.14.0/util/coding.cc#L98-L101, with this content:

```
void PutLengthPrefixedSlice(std::string* dst, const Slice& value) {
  PutVarint32(dst, value.size());
  dst->append(value.data(), value.size());
}
```

As far as I know C++, the `append` method copies the content: http://www.cplusplus.com/reference/string/string/append/.
So, using persistent handles are not needed in this case.

BTW, this didn't solve my segfault issue.

What do you think? Is this _very_ wrong and works because of some weird magic or not? Please, try it and make some strong objection against this.

I _just_ commented out 6 lines. So, some cleanup for Slice objects might be needed, plus some refactoring.
