### PR TITLE
LevelDB on OS X corruption bug

### DIFF
--- a/deps/leveldb/leveldb-1.14.0/util/env_posix.cc
+++ b/deps/leveldb/leveldb-1.14.0/util/env_posix.cc
@@ -208,6 +208,11 @@ class PosixMmapFile : public WritableFile {
   bool UnmapCurrentRegion() {
     bool result = true;
     if (base_ != NULL) {
+#if defined(OS_MACOSX)
+      if (msync(base_, limit_ - base_, MS_SYNC) != 0) {
+        result = false;
+      }
+#endif
       if (last_sync_ < limit_) {
         // Defer syncing this data until next Sync() call, if any
         pending_sync_ = true;


### PR DESCRIPTION
See http://hackingdistributed.com/2013/11/27/bitcoin-leveldb/ for details on this, patch taken directly from https://github.com/rescrv/StockLevelDB/commit/2a7e84a4bef118be3c3e8253ffbc6279b9ab54da but I would expect this to be a temporary fix until Sanjay et. al. come up with something they are more happy with. Follow discussion here: https://groups.google.com/forum/#!topic/leveldb/GXhx8YvFiig

This is the cause of https://github.com/dominictarr/npmd/issues/10

Proposed for a leveldown@0.10.2 release but I wouldn't mind an OSX user to actually test that this compiles and the tests complete.
