### PR TITLE
Allow saving of empty values.

### DIFF
--- a/src/batch.cc
+++ b/src/batch.cc
@@ -96,7 +96,7 @@ NAN_METHOD(Batch::Put) {
   v8::Local<v8::Value> keyBuffer = args[0];
   v8::Local<v8::Value> valueBuffer = args[1];
   LD_STRING_OR_BUFFER_TO_SLICE(key, keyBuffer, key)
-  LD_STRING_OR_BUFFER_TO_SLICE(value, valueBuffer, value)
+  LD_STRING_OR_BUFFER_TO_VALUE(value, valueBuffer, value)
 
   batch->batch->Put(key, value);
   if (!batch->hasData)

--- a/src/database.cc
+++ b/src/database.cc
@@ -312,7 +312,7 @@ NAN_METHOD(Database::Put) {
   v8::Local<v8::Object> keyHandle = args[0].As<v8::Object>();
   v8::Local<v8::Object> valueHandle = args[1].As<v8::Object>();
   LD_STRING_OR_BUFFER_TO_SLICE(key, keyHandle, key)
-  LD_STRING_OR_BUFFER_TO_SLICE(value, valueHandle, value)
+  LD_STRING_OR_BUFFER_TO_VALUE(value, valueHandle, value)
 
   bool sync = NanBooleanOptionValue(optionsObj, NanSymbol("sync"));
 
@@ -433,7 +433,7 @@ NAN_METHOD(Database::Batch) {
       LD_CB_ERR_IF_NULL_OR_UNDEFINED(valueBuffer, value)
 
       LD_STRING_OR_BUFFER_TO_SLICE(key, keyBuffer, key)
-      LD_STRING_OR_BUFFER_TO_SLICE(value, valueBuffer, value)
+      LD_STRING_OR_BUFFER_TO_VALUE(value, valueBuffer, value)
 
       batch->Put(key, value);
       if (!hasData)

--- a/src/leveldown.h
+++ b/src/leveldown.h
@@ -66,6 +66,25 @@ static inline void DisposeStringOrBufferFromSlice(
   }                                                                            \
   leveldb::Slice to(to ## Ch_, to ## Sz_);
 
+// NOTE: must call DisposeStringOrBufferFromSlice() on objects created here
+#define LD_STRING_OR_BUFFER_TO_VALUE(to, from, name)                           \
+  size_t to ## Sz_;                                                            \
+  char* to ## Ch_;                                                             \
+  if (node::Buffer::HasInstance(from->ToObject())) {                           \
+    to ## Sz_ = node::Buffer::Length(from->ToObject());                        \
+    to ## Ch_ = node::Buffer::Data(from->ToObject());                          \
+  } else {                                                                     \
+    v8::Local<v8::String> to ## Str = from->ToString();                        \
+    to ## Sz_ = to ## Str->Utf8Length();                                       \
+    to ## Ch_ = new char[to ## Sz_];                                           \
+    to ## Str->WriteUtf8(                                                      \
+        to ## Ch_                                                              \
+      , -1                                                                     \
+      , NULL, v8::String::NO_NULL_TERMINATION                                  \
+    );                                                                         \
+  }                                                                            \
+  leveldb::Slice to(to ## Ch_, to ## Sz_);
+
 #define LD_RETURN_CALLBACK_OR_ERROR(callback, msg)                             \
   if (!callback.IsEmpty() && callback->IsFunction()) {                         \
     v8::Local<v8::Value> argv[] = {                                            \


### PR DESCRIPTION
This fixes https://github.com/rvagg/node-levelup/issues/223. I'm not sure what to do about test cases, since those live in abstract-leveldown. Adding a test case over there would likely cause breakage for other projects.

The reason for this fix is that I'm storing the contents of some text buffers in leveldb. Occasionally, there's an empty buffer.
