### PR TITLE
Faster iterator

### DIFF
--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -1,8 +1,7 @@
-var nextTick = global.setImmediate || process.nextTick
-
-  , Iterator = function (binding, options) {
+var Iterator = function (binding, options) {
       this.binding = binding.iterator(options)
       this.cache = null
+      this.fastFuture = require('fast-future')()
     }
 
 Iterator.prototype.next = function (callback) {
@@ -15,12 +14,11 @@ Iterator.prototype.next = function (callback) {
   if (this.cache && this.cache.length) {
     row = this.cache.shift()
 
-    nextTick(function () {
+    this.fastFuture(function () {
       if (row === null)
         callback()
       else
         callback(null, row.key, row.value)
-      
     })
 
   } else {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "main": "index.js",
   "dependencies": {
     "bindings": "~1.2.0",
-    "nan": "~1.1.0"
+    "nan": "~1.1.0",
+    "fast-future": "~1.0.0"
   },
   "devDependencies": {
     "tap": "~0.4.8",


### PR DESCRIPTION
Hey, I've create a small module that will run something in `process.nextTick` until it's been done `process.maxTickDepth` number of times, when it'll instead run it in a `setImmediate` - so you'll get the performance of process.nextTick while still working as expected.

running the stream benchmarks (from levelup) shows some really fantastic results using this PR.

```
Filled source! Took 3135ms, streaming to destination...
Done! Took 10389ms, 331% of batch time
 node-levelup (master) node test/benchmarks/stream-bench.js                                 0:05:22
--------------------------------------------------------------
Filled source! Took 3004ms, streaming to destination...
Done! Took 3529ms, 117% of batch time
```

Also, kudos to @mafintosh who thought about this approach to begin with.
