### PR TITLE
Issue 109

### DIFF
--- a/src/database.cc
+++ b/src/database.cc
@@ -564,7 +564,8 @@ NAN_METHOD(Database::Iterator) {
     , optionsObj
   );
   if (try_catch.HasCaught()) {
-    node::FatalException(try_catch);
+    // NB: node::FatalException can segfault here if there is no room on stack.
+    return NanThrowError("Fatal Error in Database::Iterator!");
   }
 
   leveldown::Iterator *iterator =

--- a/src/leveldown.h
+++ b/src/leveldown.h
@@ -12,7 +12,8 @@
 #include "nan.h"
 
 static inline size_t StringOrBufferLength(v8::Local<v8::Value> obj) {
-  return node::Buffer::HasInstance(obj->ToObject())
+  return (!obj->ToObject().IsEmpty()
+    && node::Buffer::HasInstance(obj->ToObject()))
     ? node::Buffer::Length(obj->ToObject())
     : obj->ToString()->Utf8Length();
 }
@@ -46,7 +47,8 @@ static inline void DisposeStringOrBufferFromSlice(
 #define LD_STRING_OR_BUFFER_TO_SLICE(to, from, name)                           \
   size_t to ## Sz_;                                                            \
   char* to ## Ch_;                                                             \
-  if (node::Buffer::HasInstance(from->ToObject())) {                           \
+  if (!from->ToObject().IsEmpty()                                              \
+      && node::Buffer::HasInstance(from->ToObject())) {                        \
     to ## Sz_ = node::Buffer::Length(from->ToObject());                        \
     if (to ## Sz_ == 0) {                                                      \
       LD_RETURN_CALLBACK_OR_ERROR(callback, #name " cannot be an empty Buffer") \

--- a/test/iterator-recursion-test.js
+++ b/test/iterator-recursion-test.js
@@ -1,6 +1,7 @@
-const test       = require('tap').test
-    , testCommon = require('abstract-leveldown/testCommon')
-    , leveldown  = require('../')
+const test          = require('tap').test
+    , testCommon    = require('abstract-leveldown/testCommon')
+    , leveldown     = require('../')
+    , child_process = require('child_process') 
 
 var db
   , sourceData = (function () {
@@ -25,6 +26,26 @@ test('setUp db', function (t) {
   db.open(function () {
     db.batch(sourceData, t.end.bind(t))
   })
+})
+
+test('try to create an iterator with a blown stack', function (t) {
+  // Reducing the stack size down from the default 984 for the child node
+  // process makes it easier to trigger the bug condition. But making it too low
+  // causes the child process to die for other reasons.
+  var opts  = { execArgv: ["-stack-size=128"] }
+  ,   child = child_process.fork('stack-blower.js', ["run"], opts)
+  
+  child.on('message', function (m) {
+      t.ok(true, m)
+      child.disconnect()
+      
+      t.end()
+    })
+    .on('exit', function (code, sig) {
+      t.ok(false, "Child exited with code=" + code + " sig=" + sig)
+
+      t.end()
+    })
 })
 
 test('iterate over a large iterator with a large watermark', function (t) {

--- a/test/stack-blower.js
+++ b/test/stack-blower.js
@@ -1,0 +1,26 @@
+/**
+  * This test uses infinite recursion to test iterator creation with limited
+  * stack space. In order to isolate the test harness, we run in a different
+  * process. This is achieved through a fork() command in
+  * iterator-recursion-test.js. To prevent tap from trying to run this test
+  * directly, we check for a command-line argument.
+  */
+const testCommon = require('abstract-leveldown/testCommon')
+    , leveldown  = require('../')
+
+if (process.argv[2] == 'run') {
+  var db    = leveldown(testCommon.location())
+    , depth = 0
+  
+  function recurse() {
+    db.iterator({ start: '0' })
+    depth++
+    recurse()
+  }
+  
+  try {
+    recurse()
+  } catch (e) {
+    process.send("Catchable error at depth " + depth)
+  }
+}


### PR DESCRIPTION
This is a work in progress.

The segfault I encountered seems occur when we try to allocate an iterator when there are too many JS call frames on the stack. I assume this is causing Node/V8 to fail some allocations.

Unfortunately this makes it a bit tricky to test. I added an example test which causes the segfault; then I added some code which works around the allocation problems, resulting in a catchable JS Error. However, the test is still problematic, since it seems to cause timeouts, and also causes a segfault in database.close() which I don't understand.
