### PR TITLE
iterator: use snapshot from creation time

### DIFF
--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -57,6 +57,8 @@ Iterator::Iterator (
 
   options    = new leveldb::ReadOptions();
   options->fill_cache = fillCache;
+  // get a snapshot of the current state
+  options->snapshot = database->NewSnapshot();
   dbIterator = NULL;
   count      = 0;
   nexting    = false;


### PR DESCRIPTION
We're currently creating iterators lazily - the first time we call `iterator.next` it's created, and previously that was the time when the implicit snapshot was created.

After this patch, we create the snapshot when the iterator is created.

There's a test in https://github.com/rvagg/abstract-leveldown/pull/28 that fails without this test
