### PR TITLE
Fix building with clang on linux (take 2)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,7 @@
         , ['OS == "linux"', {
               'cflags': [
               ]
+            , 'cflags!': [ '-fno-tree-vrp' ]
           }]
         ]
       , "dependencies": [

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -61,6 +61,7 @@
                 '-fno-builtin-memcmp'
               , '-fPIC'
             ]
+          , 'cflags!': [ '-fno-tree-vrp' ]
         }]
       , ['OS != "win"' and 'OS != "freebsd"', {
             'cflags': [

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -43,6 +43,7 @@
                 '-Wno-sign-compare'
               , '-Wno-unused-function'
             ]
+          , 'cflags!': [ '-fno-tree-vrp' ]
         }]
       , ['OS == "freebsd"', {
             'cflags': [


### PR DESCRIPTION
Suppressing `-fno-tree-vrp` flag in order to allow building with clang.

The build on Mac (also with clang) was fine before that, this fix allows building with clang on Linux as well.

**NOTE**: although these are the exact same changes applied to master previously I cannot currently build either on Mac or Linux, instead I get the following error:

```
npm ERR! Failed resolving git HEAD (git://github.com/rvagg/abstract-leveldown) fatal: ambiguous argument 'julian-empty-values': unknown revision or path not in the working tree.
npm ERR! Failed resolving git HEAD (git://github.com/rvagg/abstract-leveldown) Use '--' to separate paths from revisions, like this:
npm ERR! Failed resolving git HEAD (git://github.com/rvagg/abstract-leveldown) 'git <command> [<revision>...] -- [<file>...]'
npm ERR! Failed resolving git HEAD (git://github.com/rvagg/abstract-leveldown)
npm ERR! Error: Command failed: fatal: ambiguous argument 'julian-empty-values': unknown revision or path not in the working tree.
npm ERR! Use '--' to separate paths from revisions, like this:
npm ERR! 'git <command> [<revision>...] -- [<file>...]'
npm ERR!
npm ERR!     at ChildProcess.exithandler (child_process.js:648:15)
npm ERR!     at ChildProcess.emit (events.js:98:17)
npm ERR!     at maybeClose (child_process.js:756:16)
npm ERR!     at Socket.<anonymous> (child_process.js:969:11)
npm ERR!     at Socket.emit (events.js:95:17)
npm ERR!     at Pipe.close (net.js:465:12)
npm ERR! If you need help, you may report this *entire* log,
npm ERR! including the npm and node versions, at:
npm ERR!     <http://github.com/npm/npm/issues>
```

However once that is resolved, the changes should fix things as before.
#### clang version on Linux

```
➝  clang --version
clang version 3.4.2 (tags/RELEASE_34/dot2-final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
```
#### clang version on Mac

As noted above this worked fine already.

```
➝  clang --version
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin13.3.0
Thread model: posix
```
#### Before this change building with clang on Linux

```
> leveldown@0.10.2 install /home/vagrant/dev/js/_forks/leveldown
> node-gyp rebuild

make: Entering directory '/home/vagrant/dev/js/_forks/leveldown/build'
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/builder.o
clang: error: unknown argument: '-fno-tree-vrp'
deps/leveldb/leveldb.target.mk:132: recipe for target 'Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/builder.o' failed
make: *** [Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/builder.o] Error 1
make: Leaving directory '/home/vagrant/dev/js/_forks/leveldown/build'
```
#### After this change building with clang on Linux

It builds successfully even though it prints a the below warning multiple times:

```
warning: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Wunknown-warning-option]
```

However this warning can be ignored and the important aspect is that it now builds successfully.
