### PR TITLE
Fix LevelDB builds for modern gcc versions

### DIFF
--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -61,6 +61,7 @@
                 '-fno-builtin-memcmp'
               , '-fPIC'
             ]
+          , 'cflags': [ '-std=c++0x' ]
           , 'cflags!': [ '-fno-tree-vrp' ]
         }]
       , ['OS != "win"' and 'OS != "freebsd"', {


### PR DESCRIPTION
LevelDB fails to compile with the current compiler flags on a Debian box running gcc 4.7.1 due to an undefined 'ssize_t'. Other users are also seeing this failure: https://github.com/rvagg/node-levelup/issues/224.

The standalone LevelDB project builds with -std=c++0x which fixes the above error.
