### PR TITLE
exposing default comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The optional `options` argument may contain:
 
 * `'compression'` *(boolean, default: `true`)*: If `true`, all *compressible* data will be run through the Snappy compression algorithm before being stored. Snappy is very fast and shouldn't gain much speed by disabling so leave this on unless you have good reason to turn it off.
 
-* `'cacheSize'` *(number, default: `8 * 1024 * 1024` = 8MB)*: The size (in bytes) of the in-memory [LRU](http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used) cache with frequently used uncompressed block contents. 
+* `'cacheSize'` *(number, default: `8 * 1024 * 1024` = 8MB)*: The size (in bytes) of the in-memory [LRU](http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used) cache with frequently used uncompressed block contents.
 
 **Advanced options**
 
@@ -83,7 +83,7 @@ The following options are for advanced performance tuning. Modify them only if y
 
 * `'blockSize'` *(number, default `4096` = 4K)*: The *approximate* size of the blocks that make up the table files. The size related to uncompressed data (hence "approximate"). Blocks are indexed in the table file and entry-lookups involve reading an entire block and parsing to discover the required entry.
 
-* `'maxOpenFiles'` *(number, default: `1000`)*: The maximum number of files that LevelDB is allowed to have open at a time. If your data store is likely to have a large working set, you may increase this value to prevent file descriptor churn. To calculate the number of files required for your working set, divide your total data by 2MB, as each table file is a maximum of 2MB. 
+* `'maxOpenFiles'` *(number, default: `1000`)*: The maximum number of files that LevelDB is allowed to have open at a time. If your data store is likely to have a large working set, you may increase this value to prevent file descriptor churn. To calculate the number of files required for your working set, divide your total data by 2MB, as each table file is a maximum of 2MB.
 
 * `'blockRestartInterval'` *(number, default: `16`)*: The number of entries before restarting the "delta encoding" of keys within blocks. Each "restart" point stores the full key for the entry, between restarts, the common prefix of the keys for those entries is omitted. Restarts are similar to the concept of keyframes in video encoding and are used to minimise the amount of space required to store keys. This is particularly helpful when using deep namespacing / prefixing in your keys.
 
@@ -183,6 +183,19 @@ Currently, the only valid properties are:
 
 * <b><code>'leveldb.sstables'</code></b>: returns a multi-line string describing all of the *sstables* that make up contents of the current database.
 
+--------------------------------------------------------
+<a name="leveldown_compare"></a>
+### leveldown#compare(keyA, keyB)
+<code>compare</code> can be used to compare two keys with the default comparator from LevelDB (this method is synchromous).
+
+Returns:
+
+* <b><code>0</code></b>: if keyA == keyB
+
+* <b><code>-1</code></b>: if keyA < keyB
+
+* <b><code>+1</code></b>: if keyA > keyB
+
 
 --------------------------------------------------------
 <a name="leveldown_iterator"></a>
@@ -259,7 +272,7 @@ The callback will be called when the destroy operation is complete, with a possi
 
 > If a DB cannot be opened, you may attempt to call this method to resurrect as much of the contents of the database as possible. Some data may be lost, so be careful when calling this function on a database that contains important information.
 
-You will find information on the *repair* operation in the *LOG* file inside the store directory. 
+You will find information on the *repair* operation in the *LOG* file inside the store directory.
 
 A `repair()` can also be used to perform a compaction of the LevelDB log into table files.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Tested & supported platforms
   * <a href="#leveldown_batch"><code><b>leveldown#batch()</b></code></a>
   * <a href="#leveldown_approximateSize"><code><b>leveldown#approximateSize()</b></code></a>
   * <a href="#leveldown_getProperty"><code><b>leveldown#getProperty()</b></code></a>
+  * <a href="#leveldown_compare"><code><b>leveldown#compare()</b></code></a>
   * <a href="#leveldown_iterator"><code><b>leveldown#iterator()</b></code></a>
   * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
   * <a href="#iterator_seek"><code><b>iterator#seek()</b></code></a>
@@ -192,9 +193,9 @@ Returns:
 
 * <b><code>0</code></b>: if keyA == keyB
 
-* <b><code>-1</code></b>: if keyA < keyB
+* <b><code>-ve number denoting the difference between the keys</code></b>: if keyA < keyB
 
-* <b><code>+1</code></b>: if keyA > keyB
+* <b><code>+ve number denoting the difference between the keys</code></b>: if keyA > keyB
 
 
 --------------------------------------------------------

--- a/leveldown.js
+++ b/leveldown.js
@@ -57,7 +57,7 @@ LevelDOWN.prototype._approximateSize = function (start, end, callback) {
   this.binding.approximateSize(start, end, callback)
 }
 
-LevelDOWN.prototype.compare = function (keyA, keyB) {
+LevelDOWN.prototype._compare = function (keyA, keyB) {
   return this.binding.compare(keyA, keyB)
 }
 

--- a/leveldown.js
+++ b/leveldown.js
@@ -57,6 +57,9 @@ LevelDOWN.prototype._approximateSize = function (start, end, callback) {
   this.binding.approximateSize(start, end, callback)
 }
 
+LevelDOWN.prototype.compare = function (keyA, keyB) {
+  return this.binding.compare(keyA, keyB)
+}
 
 LevelDOWN.prototype.getProperty = function (property) {
   if (typeof property != 'string')

--- a/src/database.cc
+++ b/src/database.cc
@@ -434,24 +434,22 @@ NAN_METHOD(Database::ApproximateSize) {
 }
 
 NAN_METHOD(Database::DefaultComparator) {
-  NanScope();
-
-  v8::Local<v8::Object> handleA = args[0].As<v8::Object>();
-  v8::Local<v8::Object> handleB = args[1].As<v8::Object>();
+  v8::Local<v8::Object> handleA = info[0].As<v8::Object>();
+  v8::Local<v8::Object> handleB = info[1].As<v8::Object>();
 
   LD_STRING_OR_BUFFER_TO_SLICE(a, handleA, a);
   LD_STRING_OR_BUFFER_TO_SLICE(b, handleB, b);
 
   leveldown::Database* database =
-      node::ObjectWrap::Unwrap<leveldown::Database>(args.This());
+      Nan::ObjectWrap::Unwrap<leveldown::Database>(info.This());
 
   v8::Local<v8::Integer> returnValue
-      = NanNew<v8::Integer>(database->DefaultDatabaseComparator(a, b));
+      = Nan::New<v8::Integer>(database->DefaultDatabaseComparator(a, b));
 
   DisposeStringOrBufferFromSlice(handleA, a);
   DisposeStringOrBufferFromSlice(handleB, b);
 
-  NanReturnValue(returnValue);
+  info.GetReturnValue().Set(returnValue);
 }
 
 NAN_METHOD(Database::GetProperty) {

--- a/src/database.cc
+++ b/src/database.cc
@@ -8,6 +8,7 @@
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>
+#include <leveldb/comparator.h>
 
 #include "leveldown.h"
 #include "database.h"
@@ -86,6 +87,12 @@ void Database::GetPropertyFromDatabase (
   db->GetProperty(property, value);
 }
 
+int Database::DefaultDatabaseComparator (
+      const leveldb::Slice& a
+    , const leveldb::Slice& b) {
+  return leveldb::BytewiseComparator()->Compare(a, b);
+}
+
 leveldb::Iterator* Database::NewIterator (leveldb::ReadOptions* options) {
   return db->NewIterator(*options);
 }
@@ -145,6 +152,7 @@ void Database::Init () {
   Nan::SetPrototypeMethod(tpl, "approximateSize", Database::ApproximateSize);
   Nan::SetPrototypeMethod(tpl, "getProperty", Database::GetProperty);
   Nan::SetPrototypeMethod(tpl, "iterator", Database::Iterator);
+  Nan::SetPrototypeMethod(tpl, "compare", Database::DefaultComparator);
 }
 
 NAN_METHOD(Database::New) {
@@ -423,6 +431,27 @@ NAN_METHOD(Database::ApproximateSize) {
   v8::Local<v8::Object> _this = info.This();
   worker->SaveToPersistent("database", _this);
   Nan::AsyncQueueWorker(worker);
+}
+
+NAN_METHOD(Database::DefaultComparator) {
+  NanScope();
+
+  v8::Local<v8::Object> handleA = args[0].As<v8::Object>();
+  v8::Local<v8::Object> handleB = args[1].As<v8::Object>();
+
+  LD_STRING_OR_BUFFER_TO_SLICE(a, handleA, a);
+  LD_STRING_OR_BUFFER_TO_SLICE(b, handleB, b);
+
+  leveldown::Database* database =
+      node::ObjectWrap::Unwrap<leveldown::Database>(args.This());
+
+  v8::Local<v8::Integer> returnValue
+      = NanNew<v8::Integer>(database->DefaultDatabaseComparator(a, b));
+
+  DisposeStringOrBufferFromSlice(handleA, a);
+  DisposeStringOrBufferFromSlice(handleB, b);
+
+  NanReturnValue(returnValue);
 }
 
 NAN_METHOD(Database::GetProperty) {

--- a/src/database.h
+++ b/src/database.h
@@ -69,6 +69,7 @@ public:
   );
   uint64_t ApproximateSizeFromDatabase (const leveldb::Range* range);
   void GetPropertyFromDatabase (const leveldb::Slice& property, std::string* value);
+  int DefaultDatabaseComparator (const leveldb::Slice& a, const leveldb::Slice& b);
   leveldb::Iterator* NewIterator (leveldb::ReadOptions* options);
   const leveldb::Snapshot* NewSnapshot ();
   void ReleaseSnapshot (const leveldb::Snapshot* snapshot);
@@ -102,6 +103,7 @@ private:
   static NAN_METHOD(Iterator);
   static NAN_METHOD(ApproximateSize);
   static NAN_METHOD(GetProperty);
+  static NAN_METHOD(DefaultComparator);
 };
 
 } // namespace leveldown

--- a/test/compare-test.js
+++ b/test/compare-test.js
@@ -1,0 +1,31 @@
+const test       = require('tap').test
+, testCommon = require('abstract-leveldown/testCommon')
+, leveldown  = require('../')
+
+var db
+
+test('setUp common', testCommon.setUp)
+
+test('setUp db', function (t) {
+  db = leveldown(testCommon.location())
+  db.open(t.end.bind(t))
+})
+
+test('test argument-less compare() throws', function (t) {
+  t.throws(
+    db.compare.bind(db)
+    , { name: 'Error', message: 'compare() requires valid `keyA`, `keyB` arguments' }
+    , 'no-arg compare() throws'
+  )
+  t.end()
+})
+
+test('test compare() returns integer', function (t) {
+  t.equal(db.compare('foo', 'foo'), 0, 'keys are equal')
+  t.equal(db.compare('foo', 'bar'), 1, 'keys are not equal')
+  t.end()
+})
+
+test('tearDown', function (t) {
+  db.close(testCommon.tearDown.bind(null, t))
+})

--- a/test/compare-test.js
+++ b/test/compare-test.js
@@ -1,4 +1,4 @@
-const test       = require('tap').test
+const test       = require('tape')
 , testCommon = require('abstract-leveldown/testCommon')
 , leveldown  = require('../')
 
@@ -22,7 +22,9 @@ test('test argument-less compare() throws', function (t) {
 
 test('test compare() returns integer', function (t) {
   t.equal(db.compare('foo', 'foo'), 0, 'keys are equal')
-  t.equal(db.compare('foo', 'bar'), 1, 'keys are not equal')
+  t.equal(db.compare('foo', 'bar'), 4, 'keys are not equal')
+  t.equal(db.compare('foo', 'hat'), -2, 'keys are not equal')
+  t.equal(db.compare('foo', 'BaZ'), 36, 'keys are not equal')
   t.end()
 })
 


### PR DESCRIPTION
Closes #28 

Would like to generalise this however for swappable comparators, i am thinking some api like

```
db.compare('comparatorname', ....) //module providing a list of custom comparators for users to choose
```

Also where do the test for this go, here or in `abstract-leveldown` ?
