### PR TITLE
[WIP] Expose snapshots to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,8 @@ Otherwise, the `callback` function will be called with the following 3 arguments
 
 --------------------------------------------------------
 <a name="leveldown_snapshot"></a>
-### leveldown#snapshot([options])
+### leveldown#snapshot()
 <code>snapshot()</code> is an instance method on an existing database object. It returns a new **Snapshot** instance. This can be passed into `get()`.
-
-#### `options`
-
-There are no options currently defined.
 
 --------------------------------------------------------
 <a name="leveldown_destroy"></a>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Tested & supported platforms
   * <a href="#leveldown_iterator"><code><b>leveldown#iterator()</b></code></a>
   * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
   * <a href="#iterator_end"><code><b>iterator#end()</b></code></a>
+  * <a href="#leveldown_snapshot"><code><b>leveldown#snapshot()</b></code></a>
   * <a href="#leveldown_destroy"><code><b>leveldown.destroy()</b></code></a>
   * <a href="#leveldown_repair"><code><b>leveldown.repair()</b></code></a>
 
@@ -125,6 +126,8 @@ The optional `options` object may contain:
 * `'fillCache'` *(boolean, default: `true`)*: LevelDB will by default fill the in-memory LRU Cache with data from a call to get. Disabling this is done by setting `fillCache` to `false`.
 
 * `'asBuffer'` *(boolean, default: `true`)*: Used to determine whether to return the `value` of the entry as a `String` or a Node.js `Buffer` object. Note that converting from a `Buffer` to a `String` incurs a cost so if you need a `String` (and the `value` can legitimately become a UFT8 string) then you should fetch it as one with `asBuffer: true` and you'll avoid this conversion cost.
+
+* `'snapshot'` *(Snapshot, default: `undefined`)*: Used to read from a previous point in time.
 
 The `callback` function will be called with a single `error` if the operation failed for any reason. If successful the first argument will be `null` and the second argument will be the `value` as a `String` or `Buffer` depending on the `asBuffer` option.
 
@@ -234,6 +237,14 @@ Otherwise, the `callback` function will be called with the following 3 arguments
 ### iterator#end(callback)
 <code>end()</code> is an instance method on an existing iterator object. The underlying LevelDB iterator will be deleted and the `callback` function will be called with no arguments if the operation is successful or with a single `error` argument if the operation failed for any reason.
 
+--------------------------------------------------------
+<a name="leveldown_snapshot"></a>
+### leveldown#snapshot([options])
+<code>snapshot()</code> is an instance method on an existing database object. It returns a new **Snapshot** instance. This can be passed into `get()`.
+
+#### `options`
+
+There are no options currently defined.
 
 --------------------------------------------------------
 <a name="leveldown_destroy"></a>

--- a/binding.gyp
+++ b/binding.gyp
@@ -36,6 +36,7 @@
           , "src/iterator_async.cc"
           , "src/leveldown.cc"
           , "src/leveldown_async.cc"
+          , "src/snapshot.cc"
         ]
     }]
 }

--- a/leveldown.js
+++ b/leveldown.js
@@ -70,6 +70,10 @@ LevelDOWN.prototype._iterator = function (options) {
   return new Iterator(this, options)
 }
 
+LevelDOWN.prototype.snapshot = function (options) {
+  return this.binding.snapshot(options)
+}
+
 
 LevelDOWN.destroy = function (location, callback) {
   if (arguments.length < 2)

--- a/src/database.cc
+++ b/src/database.cc
@@ -352,12 +352,16 @@ NAN_METHOD(Database::Get) {
   bool asBuffer = NanBooleanOptionValue(optionsObj, NanNew("asBuffer"), true);
   bool fillCache = NanBooleanOptionValue(optionsObj, NanNew("fillCache"), true);
 
+  v8::Local<v8::Object> snapshotHandle = optionsObj->Get(
+      NanNew("snapshot")).As<v8::Object>();
   const leveldb::Snapshot* dbSnapshot = NULL;
-  leveldown::Snapshot* snapshot =
-    node::ObjectWrap::Unwrap<leveldown::Snapshot>(optionsObj->
-      Get(NanNew("snapshot")).As<v8::Object>());
-  if (snapshot != NULL)
+  if (!snapshotHandle.IsEmpty() && !snapshotHandle->IsUndefined()) {
+    if (!leveldown::Snapshot::HasInstance(snapshotHandle))
+      return NanThrowError("Snapshot type is incorrect");
+    leveldown::Snapshot* snapshot =
+        node::ObjectWrap::Unwrap<leveldown::Snapshot>(snapshotHandle);
     dbSnapshot = snapshot->dbSnapshot;
+  }
 
   ReadWorker* worker = new ReadWorker(
       database

--- a/src/database.cc
+++ b/src/database.cc
@@ -567,15 +567,9 @@ NAN_METHOD(Database::Iterator) {
 NAN_METHOD(Database::Snapshot) {
   NanScope();
 
-  v8::Local<v8::Object> optionsObj;
-  if (args.Length() > 0 && args[0]->IsObject()) {
-    optionsObj = v8::Local<v8::Object>::Cast(args[0]);
-  }
-
   v8::TryCatch try_catch;
   v8::Local<v8::Object> snapshotHandle = Snapshot::NewInstance(
       args.This()
-    , optionsObj
   );
   if (try_catch.HasCaught()) {
     // NB: node::FatalException can segfault here if there is no room on stack.

--- a/src/database.cc
+++ b/src/database.cc
@@ -16,6 +16,7 @@
 #include "database_async.h"
 #include "batch.h"
 #include "iterator.h"
+#include "snapshot.h"
 
 namespace leveldown {
 
@@ -152,6 +153,7 @@ void Database::Init () {
   NODE_SET_PROTOTYPE_METHOD(tpl, "approximateSize", Database::ApproximateSize);
   NODE_SET_PROTOTYPE_METHOD(tpl, "getProperty", Database::GetProperty);
   NODE_SET_PROTOTYPE_METHOD(tpl, "iterator", Database::Iterator);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "snapshot", Database::Snapshot);
 }
 
 NAN_METHOD(Database::New) {
@@ -350,6 +352,13 @@ NAN_METHOD(Database::Get) {
   bool asBuffer = NanBooleanOptionValue(optionsObj, NanNew("asBuffer"), true);
   bool fillCache = NanBooleanOptionValue(optionsObj, NanNew("fillCache"), true);
 
+  const leveldb::Snapshot* dbSnapshot = NULL;
+  leveldown::Snapshot* snapshot =
+    node::ObjectWrap::Unwrap<leveldown::Snapshot>(optionsObj->
+      Get(NanNew("snapshot")).As<v8::Object>());
+  if (snapshot != NULL)
+    dbSnapshot = snapshot->dbSnapshot;
+
   ReadWorker* worker = new ReadWorker(
       database
     , new NanCallback(callback)
@@ -357,6 +366,7 @@ NAN_METHOD(Database::Get) {
     , asBuffer
     , fillCache
     , keyHandle
+    , dbSnapshot
   );
   // persist to prevent accidental GC
   v8::Local<v8::Object> _this = args.This();
@@ -548,6 +558,27 @@ NAN_METHOD(Database::Iterator) {
   */
 
   NanReturnValue(iteratorHandle);
+}
+
+NAN_METHOD(Database::Snapshot) {
+  NanScope();
+
+  v8::Local<v8::Object> optionsObj;
+  if (args.Length() > 0 && args[0]->IsObject()) {
+    optionsObj = v8::Local<v8::Object>::Cast(args[0]);
+  }
+
+  v8::TryCatch try_catch;
+  v8::Local<v8::Object> snapshotHandle = Snapshot::NewInstance(
+      args.This()
+    , optionsObj
+  );
+  if (try_catch.HasCaught()) {
+    // NB: node::FatalException can segfault here if there is no room on stack.
+    return NanThrowError("Fatal Error in Database::Snapshot!");
+  }
+
+  NanReturnValue(snapshotHandle);
 }
 
 

--- a/src/database.h
+++ b/src/database.h
@@ -101,6 +101,7 @@ private:
   static NAN_METHOD(Batch);
   static NAN_METHOD(Write);
   static NAN_METHOD(Iterator);
+  static NAN_METHOD(Snapshot);
   static NAN_METHOD(ApproximateSize);
   static NAN_METHOD(GetProperty);
 };

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -108,6 +108,7 @@ ReadWorker::ReadWorker (
   , bool asBuffer
   , bool fillCache
   , v8::Local<v8::Object> &keyHandle
+  , const leveldb::Snapshot *snapshot
 ) : IOWorker(database, callback, key, keyHandle)
   , asBuffer(asBuffer)
 {
@@ -115,6 +116,7 @@ ReadWorker::ReadWorker (
 
   options = new leveldb::ReadOptions();
   options->fill_cache = fillCache;
+  options->snapshot = snapshot;
   SaveToPersistent("key", keyHandle);
 };
 

--- a/src/database_async.h
+++ b/src/database_async.h
@@ -75,6 +75,7 @@ public:
     , bool asBuffer
     , bool fillCache
     , v8::Local<v8::Object> &keyHandle
+    , const leveldb::Snapshot *snapshot
   );
 
   virtual ~ReadWorker ();

--- a/src/leveldown.cc
+++ b/src/leveldown.cc
@@ -8,6 +8,7 @@
 #include "leveldown.h"
 #include "database.h"
 #include "iterator.h"
+#include "snapshot.h"
 #include "batch.h"
 #include "leveldown_async.h"
 
@@ -52,6 +53,7 @@ NAN_METHOD(RepairDB) {
 void Init (v8::Handle<v8::Object> target) {
   Database::Init();
   leveldown::Iterator::Init();
+  leveldown::Snapshot::Init();
   leveldown::Batch::Init();
 
   v8::Local<v8::Function> leveldown =

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -60,6 +60,12 @@ v8::Local<v8::Object> Snapshot::NewInstance (
   return NanEscapeScope(instance);
 }
 
+bool Snapshot::HasInstance (
+        v8::Handle<v8::Value> value
+    ) {
+  return NanHasInstance(snapshot_constructor, value);
+}
+
 NAN_METHOD(Snapshot::New) {
   NanScope();
 

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -1,0 +1,77 @@
+/* Copyright (c) 2012-2015 LevelDOWN contributors
+ * See list at <https://github.com/rvagg/node-leveldown#contributing>
+ * MIT License <https://github.com/rvagg/node-leveldown/blob/master/LICENSE.md>
+ */
+
+#include <node.h>
+#include <node_buffer.h>
+
+#include "database.h"
+#include "snapshot.h"
+
+namespace leveldown {
+
+
+static v8::Persistent<v8::FunctionTemplate> snapshot_constructor;
+
+Snapshot::Snapshot (
+    Database* database
+) : database(database)
+  , dbSnapshot(database->NewSnapshot())
+{
+  NanScope();
+
+  v8::Local<v8::Object> obj = NanNew<v8::Object>();
+  NanAssignPersistent(persistentHandle, obj);
+}
+
+Snapshot::~Snapshot () {
+  database->ReleaseSnapshot(dbSnapshot); // TODO: is this safe?
+  if (!persistentHandle.IsEmpty())
+    NanDisposePersistent(persistentHandle);
+}
+
+void Snapshot::Init () {
+  v8::Local<v8::FunctionTemplate> tpl =
+      NanNew<v8::FunctionTemplate>(Snapshot::New);
+  NanAssignPersistent(snapshot_constructor, tpl);
+  tpl->SetClassName(NanNew("Snapshot"));
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+}
+
+v8::Local<v8::Object> Snapshot::NewInstance (
+        v8::Local<v8::Object> database
+      , v8::Local<v8::Object> optionsObj
+    ) {
+  NanEscapableScope();
+
+  v8::Local<v8::Object> instance;
+  v8::Local<v8::FunctionTemplate> constructorHandle =
+      NanNew<v8::FunctionTemplate>(snapshot_constructor);
+
+  if (optionsObj.IsEmpty()) {
+    v8::Handle<v8::Value> argv[1] = { database };
+    instance = constructorHandle->GetFunction()->NewInstance(1, argv);
+  } else {
+    v8::Handle<v8::Value> argv[2] = { database, optionsObj };
+    instance = constructorHandle->GetFunction()->NewInstance(2, argv);
+  }
+
+  return NanEscapeScope(instance);
+}
+
+NAN_METHOD(Snapshot::New) {
+  NanScope();
+
+  Database* database = node::ObjectWrap::Unwrap<Database>(args[0]->ToObject());
+
+  Snapshot* snapshot = new Snapshot(
+      database
+  );
+  snapshot->Wrap(args.This());
+
+  NanReturnValue(args.This());
+}
+
+
+} // namespace leveldown

--- a/src/snapshot.cc
+++ b/src/snapshot.cc
@@ -41,7 +41,6 @@ void Snapshot::Init () {
 
 v8::Local<v8::Object> Snapshot::NewInstance (
         v8::Local<v8::Object> database
-      , v8::Local<v8::Object> optionsObj
     ) {
   NanEscapableScope();
 
@@ -49,13 +48,8 @@ v8::Local<v8::Object> Snapshot::NewInstance (
   v8::Local<v8::FunctionTemplate> constructorHandle =
       NanNew<v8::FunctionTemplate>(snapshot_constructor);
 
-  if (optionsObj.IsEmpty()) {
-    v8::Handle<v8::Value> argv[1] = { database };
-    instance = constructorHandle->GetFunction()->NewInstance(1, argv);
-  } else {
-    v8::Handle<v8::Value> argv[2] = { database, optionsObj };
-    instance = constructorHandle->GetFunction()->NewInstance(2, argv);
-  }
+  v8::Handle<v8::Value> argv[1] = { database };
+  instance = constructorHandle->GetFunction()->NewInstance(1, argv);
 
   return NanEscapeScope(instance);
 }

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -26,6 +26,7 @@ public:
       v8::Local<v8::Object> database
     , v8::Local<v8::Object> optionsObj
   );
+  static bool HasInstance (v8::Handle<v8::Value> value);
 
   Snapshot (
       Database* database

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -24,7 +24,6 @@ public:
   static void Init ();
   static v8::Local<v8::Object> NewInstance (
       v8::Local<v8::Object> database
-    , v8::Local<v8::Object> optionsObj
   );
   static bool HasInstance (v8::Handle<v8::Value> value);
 

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2012-2015 LevelDOWN contributors
+ * See list at <https://github.com/rvagg/node-leveldown#contributing>
+ * MIT License <https://github.com/rvagg/node-leveldown/blob/master/LICENSE.md>
+ */
+
+#ifndef LD_SNAPSHOT_H
+#define LD_SNAPSHOT_H
+
+#include <node.h>
+#include <vector>
+#include <nan.h>
+
+#include "leveldown.h"
+#include "database.h"
+#include "async.h"
+
+namespace leveldown {
+
+class Database;
+class AsyncWorker;
+
+class Snapshot : public node::ObjectWrap {
+public:
+  static void Init ();
+  static v8::Local<v8::Object> NewInstance (
+      v8::Local<v8::Object> database
+    , v8::Local<v8::Object> optionsObj
+  );
+
+  Snapshot (
+      Database* database
+  );
+
+  ~Snapshot ();
+
+  void Release ();
+
+  Database* database;
+  const leveldb::Snapshot* dbSnapshot;
+
+private:
+  v8::Persistent<v8::Object> persistentHandle;
+  static NAN_METHOD(New);
+};
+
+} // namespace leveldown
+
+#endif

--- a/test/snapshot-test.js
+++ b/test/snapshot-test.js
@@ -14,3 +14,35 @@ makeTest('test snapshot', function (db, t, done) {
     });
   });
 })
+
+makeTest('test snapshot invalid type with internal field',
+         function (db, t, done) {
+  db.put('x', '1', function (err) {
+    try {
+      db.get('x', { snapshot: db.iterator() }, function(err, data) {
+        t.notOk(true, 'should have thrown exception');
+        done();
+      });
+    } catch (err) {
+      t.ok(err);
+      t.equal('Snapshot type is incorrect', err.message, 'exception message');
+      done();
+    }
+  });
+})
+
+makeTest('test snapshot invalid type without internal field',
+         function (db, t, done) {
+  db.put('x', '1', function (err) {
+    try {
+      db.get('x', { snapshot: Object() }, function(err, data) {
+        t.notOk(true, 'should have thrown exception');
+        done();
+      });
+    } catch (err) {
+      t.ok(err);
+      t.equal('Snapshot type is incorrect', err.message, 'exception message');
+      done();
+    }
+  });
+})

--- a/test/snapshot-test.js
+++ b/test/snapshot-test.js
@@ -1,0 +1,16 @@
+const test       = require('tap').test
+    , testCommon = require('abstract-leveldown/testCommon')
+    , leveldown  = require('../')
+    , makeTest   = require('./make-test')
+
+makeTest('test snapshot', function (db, t, done) {
+  db.put('x', '1', function (err) {
+    var snapshot = db.snapshot();
+    db.put('x', '2', function (err) {
+      db.get('x', { snapshot: snapshot }, function(err, data) {
+        t.equal('' + data, '1', 'should have read from snapshot');
+        done();
+      });
+    });
+  });
+})


### PR DESCRIPTION
I want to have access to leveldb snapshots from JS so that I can build a transaction library with snapshot isolation. See rvagg/node-levelup#15 and rvagg/node-levelup#138.

I tried implementing this, and it seems to sort of work. I'm experienced with C++ but entirely new to Node/v8, so I'm probably doing a lot of things wrong. Specifically, this is probably unsafe with respect to memory management. It'd be great if someone with more experience could review the patch.

There's also a question as to how the API should work. I added the snapshot as an option to db#get(). Another alternative is to add a Snapshot#get() method. Also, maybe the snapshot should also be an option for iterators. Thoughts?

Again, I'm new to this, so I'm looking for feedback. I don't think this is ready to merge.
