### PR TITLE
running node-gyp in install phase is better

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
   },
   "scripts": {
     "test": "tap test/*-test.js --stderr",
-    "preinstall": "true",
-    "postinstall": "JOBS=max node-gyp rebuild"
+    "install": "JOBS=max node-gyp rebuild"
   },
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
This is obviously much better since `npm` actually uses `install` https://github.com/npm/npm/blob/master/node_modules/read-package-json/read-json.js#L161