### PR TITLE
Revert "run node-gyp in the postinstall phase"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ before_install:
 script:
   - n 0.10
   - node -v; which node; npm -v; which npm
-  - npm install
+  - JOBS=max npm install
   - npm test && rm -rf node_modules/
 
   - n latest
   - node -v; which node; npm -v; which npm
-  - npm install
+  - JOBS=max npm install
   - npm test && rm -rf node_modules/
 
   - n io latest
   - iojs -v; which iojs; npm -v; which npm
-  - npm install
+  - JOBS=max npm install
   - npm test
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     "tap": "~0.4.12"
   },
   "scripts": {
-    "test": "tap test/*-test.js --stderr",
-    "preinstall": "true",
-    "postinstall": "JOBS=max node-gyp rebuild"
+    "test": "tap test/*-test.js --stderr"
   },
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
This reverts commit 71f4e6b0809d7be5a81135ee51c6ba5931c87353.

I'm undoing this change since I don't know for sure if it works on windows or not.