### PR TITLE
use carat for nan instead of tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "abstract-leveldown": "~2.1.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
-    "nan": "~1.5.0"
+    "nan": "^1.5.0"
   },
   "devDependencies": {
     "du": "~0.1.0",


### PR DESCRIPTION
before it was `nan ~1.5.0`, this changes it to `nan ^1.5.0`

I need this so I can get latest nan so I can use leveldown with electron (Formerly atom-shell), since nan is broken in 1.5.0 but works >= 1.6.0