### PR TITLE
pass db to abstractIterator so gc keeps it

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -3,7 +3,7 @@ const util             = require('util')
 
 
 function Iterator (db, options) {
-  AbstractIterator.call(this, options)
+  AbstractIterator.call(this, db)
 
   this.binding    = db.binding.iterator(options)
   this.cache      = null


### PR DESCRIPTION
the abstract iterator signature is `(db)` and not `(options)` (see https://github.com/Level/abstract-leveldown/blob/master/abstract-iterator.js#L3). passing the db will prevent gc from cleaning up the db when you only have references to iterators.