### PR TITLE
add test for liveBackup

### DIFF
--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -272,6 +272,7 @@ LiveBackupWorker::LiveBackupWorker (
 ) : AsyncWorker(database, callback)
   , name(name)
 {
+  NanScope();
   SaveToPersistent("name", nameHandle);
 };
 
@@ -282,6 +283,7 @@ void LiveBackupWorker::Execute () {
 }
 
 void LiveBackupWorker::WorkComplete () {
+  NanScope();
   DisposeStringOrBufferFromSlice(GetFromPersistent("name"), name);
   AsyncWorker::WorkComplete();
 }

--- a/test/livebackup-test.js
+++ b/test/livebackup-test.js
@@ -1,0 +1,32 @@
+const test       = require('tap').test
+    , testCommon = require('abstract-leveldown/testCommon')
+    , leveldown  = require('../')
+
+var db
+
+test('setUp common', testCommon.setUp)
+
+test('setUp db', function (t) {
+  db = leveldown(testCommon.location())
+  db.open(t.end.bind(t))
+})
+
+test('liveBackup', function (t) {
+  var key = 'beep'
+    , value = 'boop'
+  db.put(key, value, function (err) {
+    t.ok(!err, 'no put error')
+    db.get(key, function (err, _value) {
+      t.equal(_value.toString(), value)
+      var backup = 'backup-' + Date.now()
+      db.liveBackup(backup, function (err) {
+        t.ok(!err, 'no liveBackup error')
+        t.end()
+      })
+    })
+  })
+})
+
+test('tearDown', function (t) {
+  db.close(testCommon.tearDown.bind(null, t))
+})

--- a/test/livebackup-test.js
+++ b/test/livebackup-test.js
@@ -8,22 +8,37 @@ test('setUp common', testCommon.setUp)
 
 test('setUp db', function (t) {
   db = leveldown(testCommon.location())
-  db.open(t.end.bind(t))
-})
-
-test('liveBackup', function (t) {
-  var key = 'beep'
-    , value = 'boop'
-  db.put(key, value, function (err) {
-    t.ok(!err, 'no put error')
-    db.get(key, function (err, _value) {
-      t.equal(_value.toString(), value)
-      var backup = 'backup-' + Date.now()
-      db.liveBackup(backup, function (err) {
-        t.ok(!err, 'no liveBackup error')
+  db.open(function (err) {
+    t.ok(!err, 'no error')
+    var key = 'beep'
+      , value = 'boop'
+    db.put(key, value, function (err) {
+      t.ok(!err, 'no put error')
+      db.get(key, function (err, _value) {
+        t.equal(_value.toString(), value)
         t.end()
       })
     })
+  })
+})
+
+test('liveBackup', function (t) {
+  t.throws(db.liveBackup.bind(db, null), {
+    name: 'Error',
+    message: 'liveBackup() requires a valid `name` argument'
+  })
+  t.throws(db.liveBackup.bind(db), {
+    name: 'Error',
+    message: 'liveBackup() requires a valid `name` argument'
+  })
+  t.throws(db.liveBackup.bind(db, function () {}), {
+    name: 'Error',
+    message: 'liveBackup() requires a valid `name` argument'
+  })
+  var backup = 'backup-' + Date.now()
+  db.liveBackup(backup, function (err) {
+    t.ok(!err, 'no liveBackup error')
+    t.end()
   })
 })
 

--- a/test/livebackup-test.js
+++ b/test/livebackup-test.js
@@ -1,13 +1,17 @@
 const test       = require('tap').test
     , testCommon = require('abstract-leveldown/testCommon')
     , leveldown  = require('../')
+    , fs         = require('fs')
+    , join       = require('path').join
 
 var db
+  , location
 
 test('setUp common', testCommon.setUp)
 
 test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
+  location = testCommon.location()
+  db = leveldown(location)
   db.open(function (err) {
     t.ok(!err, 'no error')
     var key = 'beep'
@@ -23,22 +27,26 @@ test('setUp db', function (t) {
 })
 
 test('liveBackup', function (t) {
-  t.throws(db.liveBackup.bind(db, null), {
+  var expected = {
     name: 'Error',
     message: 'liveBackup() requires a valid `name` argument'
-  })
-  t.throws(db.liveBackup.bind(db), {
-    name: 'Error',
-    message: 'liveBackup() requires a valid `name` argument'
-  })
-  t.throws(db.liveBackup.bind(db, function () {}), {
-    name: 'Error',
-    message: 'liveBackup() requires a valid `name` argument'
-  })
-  var backup = 'backup-' + Date.now()
-  db.liveBackup(backup, function (err) {
+  }
+  t.throws(db.liveBackup.bind(db, null), expected)
+  t.throws(db.liveBackup.bind(db), expected)
+  t.throws(db.liveBackup.bind(db, function () {}), expected)
+  var now = Date.now()
+  db.liveBackup(now, function (err) {
     t.ok(!err, 'no liveBackup error')
-    t.end()
+    var backup = join(location, 'backup-' + now)
+    fs.stat(backup, function (err, stats) {
+      t.ok(!err, 'no error')
+      t.ok(stats.isDirectory(), 'backup dir should exist')
+      fs.readdir(backup, function (err, files) {
+        t.ok(!err, 'no error')
+        t.ok(files.length > 0, 'should contain some files')
+        t.end()
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Works on `0.10.38` and `0.12.2` but segfaults on iojs `1.8.1` and `2.0.0`. The error I get is:

```
$ node test/livebackup-test.js 
TAP version 13
# setUp common
ok 1 cleanup returned an error
# setUp db
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
Aborted (core dumped)
```

Call stack from core dump:

```
#0  0x00007fa98d414e37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007fa98d416528 in __GI_abort () at abort.c:89
#2  0x0000000000cd40d3 in node::OnFatalError(char const*, char const*) ()
#3  0x0000000000829205 in v8::Utils::ReportApiFailure(char const*, char const*) ()
#4  0x00000000009b111f in v8::internal::HandleScope::Extend(v8::internal::Isolate*) ()
#5  0x0000000000829cb8 in v8::EscapableHandleScope::EscapableHandleScope(v8::Isolate*) ()
#6  0x00007fa98a9776ba in leveldown::LiveBackupWorker::WorkComplete() () from /home/lms/src/leveldb-repos/leveldown/build/Release/leveldown.node
#7  0x00007fa98a96d71d in NanAsyncExecuteComplete(uv_work_s*) () from /home/lms/src/leveldb-repos/leveldown/build/Release/leveldown.node
#8  0x0000000000d4e0cd in uv__work_done (handle=0x13252d0 <default_loop_struct+176>) at ../deps/uv/src/threadpool.c:236
#9  0x0000000000d4fe76 in uv__async_event (loop=0x1325220 <default_loop_struct>, w=<optimized out>, nevents=<optimized out>) at ../deps/uv/src/unix/async.c:92
#10 0x0000000000d4ff33 in uv__async_io (loop=0x1325220 <default_loop_struct>, w=0x13253e8 <default_loop_struct+456>, events=<optimized out>) at ../deps/uv/src/unix/async.c:132
#11 0x0000000000d5eddd in uv__io_poll (loop=loop@entry=0x1325220 <default_loop_struct>, timeout=29995) at ../deps/uv/src/unix/linux-core.c:319
#12 0x0000000000d509c6 in uv_run (loop=0x1325220 <default_loop_struct>, mode=UV_RUN_ONCE) at ../deps/uv/src/unix/core.c:324
#13 0x0000000000cdf060 in node::Start(int, char**) ()
#14 0x00007fa98d3ffec5 in __libc_start_main (main=0x6742e0 <main>, argc=2, argv=0x7ffd9b57ae28, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffd9b57ae18) at libc-start.c:287
#15 0x00000000006744ad in _start ()
```

Not sure what's going on here. Will try to investigate more tomorrow.

/cc @rvagg @mcollina 