### PR TITLE
promote early failure

### DIFF
--- a/src/batch.cc
+++ b/src/batch.cc
@@ -40,15 +40,17 @@ void Batch::Init () {
 
 NAN_METHOD(Batch::New) {
   NanScope();
+  
+  assert(args.Length()>0 && "Batch::New expects an Object argument");
 
   Database* database = node::ObjectWrap::Unwrap<Database>(args[0]->ToObject());
   v8::Local<v8::Object> optionsObj;
 
+  bool sync = false;
   if (args.Length() > 1 && args[1]->IsObject()) {
     optionsObj = v8::Local<v8::Object>::Cast(args[1]);
+    sync = BooleanOptionValue(optionsObj, "sync");
   }
-
-  bool sync = BooleanOptionValue(optionsObj, "sync");
 
   Batch* batch = new Batch(database, sync);
   batch->Wrap(args.This());
@@ -82,6 +84,10 @@ v8::Handle<v8::Value> Batch::NewInstance (
 NAN_METHOD(Batch::Put) {
   NanScope();
 
+  if (args.Length() < 2) {
+    return NanThrowError("Batch::Put expects 2 arguments (keyBuffer, valueBuffer)");
+  }
+
   Batch* batch = ObjectWrap::Unwrap<Batch>(args.Holder());
   v8::Handle<v8::Function> callback; // purely for the error macros
 
@@ -102,6 +108,10 @@ NAN_METHOD(Batch::Put) {
 
 NAN_METHOD(Batch::Del) {
   NanScope();
+  
+  if (args.Length() < 1) {
+    return NanThrowError("Batch::Del expects an argument (keyBuffer)");
+  }
 
   Batch* batch = ObjectWrap::Unwrap<Batch>(args.Holder());
 
@@ -132,6 +142,10 @@ NAN_METHOD(Batch::Clear) {
 
 NAN_METHOD(Batch::Write) {
   NanScope();
+  
+  if (args.Length() < 1 || !args[0]->IsFunction()) {
+    return NanThrowError("Batch::Write expects a function argument");
+  }
 
   Batch* batch = ObjectWrap::Unwrap<Batch>(args.Holder());
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -383,7 +383,7 @@ NAN_METHOD(Database::Delete) {
 NAN_METHOD(Database::Batch) {
   NanScope();
 
-  if (args.Length() == 0 || (args.Length() == 1 && args[0]->IsObject())) {
+  if (args.Length() == 0 || (args.Length() > 0 && args[0]->IsObject())) {
     v8::Local<v8::Object> optionsObj;
     if (args.Length() > 0 && args[0]->IsObject()) {
       optionsObj = args[0].As<v8::Object>();

--- a/src/database.cc
+++ b/src/database.cc
@@ -128,6 +128,10 @@ void Database::CloseDatabase () {
 
 NAN_METHOD(LevelDOWN) {
   NanScope();
+  
+  if (args.Length() < 1 || !args[0]->IsString()) {
+    return NanThrowError("LevelDOWN expects a string argument");
+  }
 
   v8::Local<v8::String> location = args[0].As<v8::String>();
   NanReturnValue(Database::NewInstance(location));
@@ -152,6 +156,8 @@ void Database::Init () {
 NAN_METHOD(Database::New) {
   NanScope();
 
+  assert(args.Length()>0 && "Database::New expects an Object argument");
+  
   Database* obj = new Database(args[0]);
   obj->Wrap(args.This());
 
@@ -282,6 +288,10 @@ NAN_METHOD(Database::Close) {
 
 NAN_METHOD(Database::Put) {
   NanScope();
+  
+  if (args.Length() < 2) {
+    return NanThrowError("Database::Put expects 2 arguments (keyHandle, valueHandle)");
+  }
 
   LD_METHOD_SETUP_COMMON(put, 2, 3)
 
@@ -312,6 +322,10 @@ NAN_METHOD(Database::Put) {
 
 NAN_METHOD(Database::Get) {
   NanScope();
+  
+  if (args.Length() < 1) {
+    return NanThrowError("Database::Get expects an argument (keyHandle)");
+  }
 
   LD_METHOD_SETUP_COMMON(get, 1, 2)
 
@@ -339,6 +353,10 @@ NAN_METHOD(Database::Get) {
 
 NAN_METHOD(Database::Delete) {
   NanScope();
+  
+  if (args.Length() < 1) {
+    return NanThrowError("Database::Delete expects an argument (keyHandle)");
+  }
 
   LD_METHOD_SETUP_COMMON(del, 1, 2)
 
@@ -365,7 +383,7 @@ NAN_METHOD(Database::Delete) {
 NAN_METHOD(Database::Batch) {
   NanScope();
 
-  if ((args.Length() == 0 || args.Length() == 1) && !args[0]->IsArray()) {
+  if (args.Length() <= 1 && !args[0]->IsArray()) {
     v8::Local<v8::Object> optionsObj;
     if (args.Length() > 0 && args[0]->IsObject()) {
       optionsObj = args[0].As<v8::Object>();
@@ -433,6 +451,11 @@ NAN_METHOD(Database::Batch) {
 
 NAN_METHOD(Database::ApproximateSize) {
   NanScope();
+  
+  if (args.Length() < 2) {
+    return NanThrowError(
+        "Database::ApproximateSize expects 2 arguments (startHandle, endHandle)");
+  }
 
   v8::Local<v8::Object> startHandle = args[0].As<v8::Object>();
   v8::Local<v8::Object> endHandle = args[1].As<v8::Object>();
@@ -460,6 +483,10 @@ NAN_METHOD(Database::ApproximateSize) {
 
 NAN_METHOD(Database::GetProperty) {
   NanScope();
+  
+  if (args.Length() < 1) {
+    return NanThrowError("Database::GetProperty expects an argument (propertyHandle)");
+  }
 
   v8::Local<v8::Value> propertyHandle = args[0].As<v8::Object>();
   v8::Local<v8::Function> callback; // for LD_STRING_OR_BUFFER_TO_SLICE

--- a/src/database.cc
+++ b/src/database.cc
@@ -383,7 +383,7 @@ NAN_METHOD(Database::Delete) {
 NAN_METHOD(Database::Batch) {
   NanScope();
 
-  if (args.Length() <= 1 && !args[0]->IsArray()) {
+  if (args.Length() == 0 || (args.Length() == 1 && args[0]->IsObject())) {
     v8::Local<v8::Object> optionsObj;
     if (args.Length() > 0 && args[0]->IsObject()) {
       optionsObj = args[0].As<v8::Object>();

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -203,6 +203,10 @@ void checkEndCallback (Iterator* iterator) {
 NAN_METHOD(Iterator::Next) {
   NanScope();
 
+  if (args.Length() < 1 || !args[0]->IsFunction()) {
+    return NanThrowError("Iterator::Next expects a function argument");
+  }
+  
   Iterator* iterator = node::ObjectWrap::Unwrap<Iterator>(args.This());
 
   v8::Local<v8::Function> callback = args[0].As<v8::Function>();
@@ -224,6 +228,10 @@ NAN_METHOD(Iterator::Next) {
 NAN_METHOD(Iterator::End) {
   NanScope();
 
+  if (args.Length() < 1 || !args[0]->IsFunction()) {
+    return NanThrowError("Iterator::End expects a function argument");
+  }
+  
   Iterator* iterator = node::ObjectWrap::Unwrap<Iterator>(args.This());
 
   v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(args[0]);
@@ -282,6 +290,8 @@ v8::Local<v8::Object> Iterator::NewInstance (
 
 NAN_METHOD(Iterator::New) {
   NanScope();
+  
+  assert(args.Length()>0 && "Iterator::New expects an Object argument");
 
   Database* database = node::ObjectWrap::Unwrap<Database>(args[0]->ToObject());
 

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -353,7 +353,7 @@ NAN_METHOD(Iterator::New) {
       }
     }
 
-    if (!optionsObj.IsEmpty() && optionsObj->Has(NanNew("limit"))) {
+    if (optionsObj->Has(NanNew("limit"))) {
       limit = v8::Local<v8::Integer>::Cast(optionsObj->Get(
           NanNew("limit")))->Value();
     }

--- a/src/leveldown.cc
+++ b/src/leveldown.cc
@@ -15,6 +15,10 @@ namespace leveldown {
 
 NAN_METHOD(DestroyDB) {
   NanScope();
+  
+  if (args.Length() < 1 || !args[0]->IsString()) {
+    return NanThrowError("DestroyDB expects an argument (location)");
+  }
 
   NanUtf8String* location = new NanUtf8String(args[0]);
 
@@ -33,6 +37,10 @@ NAN_METHOD(DestroyDB) {
 
 NAN_METHOD(RepairDB) {
   NanScope();
+  
+  if (args.Length() < 1 || !args[0]->IsString()) {
+    return NanThrowError("RepairDB expects an argument (location)");
+  }
 
   NanUtf8String* location = new NanUtf8String(args[0]);
 


### PR DESCRIPTION
Although It’s **not expected** (in many places) that throwing an
exception is going to save an application, promoting an early failure
with an explanation could help with pre-production stability efforts.