### PR TITLE
added iterator.seek()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Tested & supported platforms
   * <a href="#leveldown_getProperty"><code><b>leveldown#getProperty()</b></code></a>
   * <a href="#leveldown_iterator"><code><b>leveldown#iterator()</b></code></a>
   * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
+  * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
   * <a href="#iterator_end"><code><b>iterator#end()</b></code></a>
   * <a href="#leveldown_destroy"><code><b>leveldown.destroy()</b></code></a>
   * <a href="#leveldown_repair"><code><b>leveldown.repair()</b></code></a>
@@ -228,6 +229,14 @@ Otherwise, the `callback` function will be called with the following 3 arguments
 * `key` - either a `String` or a Node.js `Buffer` object depending on the `keyAsBuffer` argument when the `iterator()` was called.
 * `value` - either a `String` or a Node.js `Buffer` object depending on the `valueAsBuffer` argument when the `iterator()` was called.
 
+
+--------------------------------------------------------
+<a name="iterator_seek"></a>
+### iterator#seek(key)
+<code>seek()</code> is an instance method on an existing iterator object, used to seek the underlying LevelDB iterator to a given key.
+
+by calling <code>seek(key)</code> subsequent calls to <code>next(cb)</code> will return key/values larger or smaller than <code>key</code>
+based on your <code>reverse</code> setting in the iterator constructor.
 
 --------------------------------------------------------
 <a name="iterator_end"></a>

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Tested & supported platforms
   * <a href="#leveldown_getProperty"><code><b>leveldown#getProperty()</b></code></a>
   * <a href="#leveldown_iterator"><code><b>leveldown#iterator()</b></code></a>
   * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
-  * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>
+  * <a href="#iterator_seek"><code><b>iterator#seek()</b></code></a>
   * <a href="#iterator_end"><code><b>iterator#end()</b></code></a>
   * <a href="#leveldown_destroy"><code><b>leveldown.destroy()</b></code></a>
   * <a href="#leveldown_repair"><code><b>leveldown.repair()</b></code></a>
@@ -235,8 +235,7 @@ Otherwise, the `callback` function will be called with the following 3 arguments
 ### iterator#seek(key)
 <code>seek()</code> is an instance method on an existing iterator object, used to seek the underlying LevelDB iterator to a given key.
 
-by calling <code>seek(key)</code> subsequent calls to <code>next(cb)</code> will return key/values larger or smaller than <code>key</code>
-based on your <code>reverse</code> setting in the iterator constructor.
+By calling <code>seek(key)</code>, subsequent calls to <code>next(cb)</code> will return key/values larger or smaller than key, based on your <code>reverse</code> setting in the iterator constructor.
 
 --------------------------------------------------------
 <a name="iterator_end"></a>

--- a/iterator.js
+++ b/iterator.js
@@ -13,6 +13,11 @@ function Iterator (db, options) {
 
 util.inherits(Iterator, AbstractIterator)
 
+Iterator.prototype.seek = function (key) {
+  if (typeof key !== 'string') throw new Error('seek requires a string key')
+  this.cache = null
+  this.binding.seek(key)
+}
 
 Iterator.prototype._next = function (callback) {
   var that = this

--- a/iterator.js
+++ b/iterator.js
@@ -14,7 +14,8 @@ function Iterator (db, options) {
 util.inherits(Iterator, AbstractIterator)
 
 Iterator.prototype.seek = function (key) {
-  if (typeof key !== 'string') throw new Error('seek requires a string key')
+  if (typeof key !== 'string')
+    throw new Error('seek requires a string key')
   this.cache = null
   this.binding.seek(key)
 }

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -218,8 +218,7 @@ NAN_METHOD(Iterator::Seek) {
     int cmp = dbIterator->key().compare(*key);
     if (cmp > 0 && iterator->reverse) {
       dbIterator->Prev();
-    }
-    if (cmp < 0 && !iterator->reverse) {
+    } else if (cmp < 0 && !iterator->reverse) {
       dbIterator->Next();
     }
   } else {
@@ -233,8 +232,7 @@ NAN_METHOD(Iterator::Seek) {
       if (cmp > 0 && iterator->reverse) {
         dbIterator->SeekToFirst();
         dbIterator->Prev();
-      }
-      if (cmp < 0 && !iterator->reverse) {
+      } else if (cmp < 0 && !iterator->reverse) {
         dbIterator->SeekToLast();
         dbIterator->Next();
       }

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -62,6 +62,7 @@ private:
   leveldb::ReadOptions* options;
   leveldb::Slice* start;
   std::string* end;
+  bool seeking;
   bool reverse;
   bool keys;
   bool values;
@@ -87,6 +88,7 @@ private:
   bool GetIterator ();
 
   static NAN_METHOD(New);
+  static NAN_METHOD(Seek);
   static NAN_METHOD(Next);
   static NAN_METHOD(End);
 };

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -2,5 +2,68 @@ const test       = require('tape')
     , testCommon = require('abstract-leveldown/testCommon')
     , leveldown  = require('../')
     , abstract   = require('abstract-leveldown/abstract/iterator-test')
+    , make       = require('./make')
 
 abstract.all(leveldown, test, testCommon)
+
+make('iterator throws if key is not a string', function (db, t, done) {
+  var ite = db.iterator()
+  var error
+  try {
+    ite.seek()
+  } catch (e) {
+    error = e
+  }
+
+  t.ok(error, 'had error')
+  t.end()
+})
+
+make('iterator is seekable', function (db, t, done) {
+  var ite = db.iterator()
+  ite.seek('two')
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error')
+    t.same(key.toString(), 'two', 'key matches')
+    t.same(value.toString(), '2', 'value matches')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.same(key, undefined, 'end of iterator')
+      t.same(value, undefined, 'end of iterator')
+      ite.end(done)
+    })
+  })
+})
+
+make('reverse seek in the middle', function (db, t, done) {
+  var ite = db.iterator({reverse: true, limit: 1})
+  ite.seek('three!')
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error')
+    t.same(key.toString(), 'three', 'key matches')
+    t.same(value.toString(), '3', 'value matches')
+    ite.end(done)
+  })
+})
+
+make('iterator invalid seek', function (db, t, done) {
+  var ite = db.iterator()
+  ite.seek('zzz')
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error')
+    t.same(key, undefined, 'end of iterator')
+    t.same(value, undefined, 'end of iterator')
+    ite.end(done)
+  })
+})
+
+make('reverse seek from invalid range', function (db, t, done) {
+  var ite = db.iterator({reverse: true})
+  ite.seek('zzz')
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error')
+    t.same(key.toString(), 'two', 'end of iterator')
+    t.same(value.toString(), '2', 'end of iterator')
+    ite.end(done)
+  })
+})


### PR DESCRIPTION
I need to be able to seek an iterator for something I'm implementing for dat so I've added support for that.
We store keys like this

```
<key>!<change number> = <value>
```

because that allows to checkout previous versions of a key based on a change number (a change number basically represents the state of the database at a current point in time)

Currently we do this like this

``` js
var rs = db.createReadStream({
  gt: key + '!',
  lte: key + '!' + lexint.pack(changeNumber, 'hex'),
  limit:1,
  reverse:true
})

rs.once('data', function (data) {
  // this is the value we want
})
```

But this means that we have to do a read-stream (iterator) for every single lookup. Using `iterator.seek(key)` we can just have a single iterator and do it like this

``` js
var ite = db.iterator({reverse:true})
// ...
ite.seek(key + '!' + lexint.pack(changeNumber, 'hex'))
ite.next(console.log)
// ...
ite.seek(anotherKey + '!' + lexint.pack(changeNumber, 'hex'))
ite.next(console.log)
```