### PR TITLE
Remove hash_test.cc source

### DIFF
--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -199,7 +199,6 @@
       , 'leveldb-<(ldbversion)/util/filter_policy.cc'
       , 'leveldb-<(ldbversion)/util/hash.cc'
       , 'leveldb-<(ldbversion)/util/hash.h'
-      , 'leveldb-<(ldbversion)/util/hash_test.cc'
       , 'leveldb-<(ldbversion)/util/logging.cc'
       , 'leveldb-<(ldbversion)/util/logging.h'
       , 'leveldb-<(ldbversion)/util/mutexlock.h'


### PR DESCRIPTION
This removes `leveldb-<(ldbversion)/util/hash_test.cc` in `deps/leveldb/leveldb.gyp` as suggested by the brilliant @rvagg in #197 to fix the build for SmartOS (not tested elsewhere).