### PR TITLE
update prebuild for --strip functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
     "nan": "~2.0.0",
-    "prebuild": "~2.3.3"
+    "prebuild": "~2.4.0"
   },
   "devDependencies": {
     "async": "~1.0.0",
@@ -51,7 +51,7 @@
   "scripts": {
     "install": "prebuild --download",
     "test": "tape test/*-test.js | faucet",
-    "prebuild": "prebuild --verbose"
+    "prebuild": "prebuild --verbose --strip"
   },
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
`npm run prebuild` will now shell out to `strip(1)` for `darwin` and `linux`