### PR TITLE
update prebuild for --debug support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
     "nan": "~2.0.0",
-    "prebuild": "~2.4.0"
+    "prebuild": "^2.5.0"
   },
   "devDependencies": {
     "async": "~1.0.0",


### PR DESCRIPTION
Enables `--debug` functionality:

```
$ npm i --build-from-source --debug

> leveldown@1.4.1 install /home/lms/src/leveldb-repos/leveldown
> prebuild --download

make: Entering directory '/home/lms/src/leveldb-repos/leveldown/build'
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/builder.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/db_impl.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/db_iter.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/filename.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/dbformat.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/leveldb_main.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/log_reader.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/log_writer.o
  CXX(target) Debug/obj.target/leveldb/deps/leveldb/leveldb-1.18.0/db/memtable.o
..
```