### PR TITLE
Seek multiple times and support Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The optional `options` argument may contain:
 
 * `'compression'` *(boolean, default: `true`)*: If `true`, all *compressible* data will be run through the Snappy compression algorithm before being stored. Snappy is very fast and shouldn't gain much speed by disabling so leave this on unless you have good reason to turn it off.
 
-* `'cacheSize'` *(number, default: `8 * 1024 * 1024` = 8MB)*: The size (in bytes) of the in-memory [LRU](http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used) cache with frequently used uncompressed block contents. 
+* `'cacheSize'` *(number, default: `8 * 1024 * 1024` = 8MB)*: The size (in bytes) of the in-memory [LRU](http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used) cache with frequently used uncompressed block contents.
 
 **Advanced options**
 
@@ -83,7 +83,7 @@ The following options are for advanced performance tuning. Modify them only if y
 
 * `'blockSize'` *(number, default `4096` = 4K)*: The *approximate* size of the blocks that make up the table files. The size related to uncompressed data (hence "approximate"). Blocks are indexed in the table file and entry-lookups involve reading an entire block and parsing to discover the required entry.
 
-* `'maxOpenFiles'` *(number, default: `1000`)*: The maximum number of files that LevelDB is allowed to have open at a time. If your data store is likely to have a large working set, you may increase this value to prevent file descriptor churn. To calculate the number of files required for your working set, divide your total data by 2MB, as each table file is a maximum of 2MB. 
+* `'maxOpenFiles'` *(number, default: `1000`)*: The maximum number of files that LevelDB is allowed to have open at a time. If your data store is likely to have a large working set, you may increase this value to prevent file descriptor churn. To calculate the number of files required for your working set, divide your total data by 2MB, as each table file is a maximum of 2MB.
 
 * `'blockRestartInterval'` *(number, default: `16`)*: The number of entries before restarting the "delta encoding" of keys within blocks. Each "restart" point stores the full key for the entry, between restarts, the common prefix of the keys for those entries is omitted. Restarts are similar to the concept of keyframes in video encoding and are used to minimise the amount of space required to store keys. This is particularly helpful when using deep namespacing / prefixing in your keys.
 
@@ -222,8 +222,9 @@ The optional `options` object may contain:
 the `callback` function will be called with no arguments in any of the following situations:
 
 * the iterator comes to the end of the store
-* the `end` key has been reached; or
-* the `limit` has been reached
+* the `end` key has been reached
+* the `limit` has been reached; or
+* the last `seek()` was out of range
 
 Otherwise, the `callback` function will be called with the following 3 arguments:
 
@@ -235,9 +236,11 @@ Otherwise, the `callback` function will be called with the following 3 arguments
 --------------------------------------------------------
 <a name="iterator_seek"></a>
 ### iterator#seek(key)
-<code>seek()</code> is an instance method on an existing iterator object, used to seek the underlying LevelDB iterator to a given key.
+<code>seek()</code> is an instance method on an existing iterator object, used to seek the underlying LevelDB iterator to a given key or the closest matching key.
 
-By calling <code>seek(key)</code>, subsequent calls to <code>next(cb)</code> will return key/values larger or smaller than `key`, based on your <code>reverse</code> setting in the iterator constructor.
+Your <code>reverse</code> setting in the iterator constructor affects the seek direction. If `reverse` is false, subsequent calls to <code>next(cb)</code> will yield entries equal to or larger than `key`. If `reverse` is true, subsequent calls to <code>next(cb)</code> will yield entries equal to or smaller than `key`. If you specified one or more range options in the constructor (`gt`, `gte`, `lt`, `lte`, `start` or `end`) and `key` does not match this range, subsequent calls to <code>next(cb)</code> will yield none.
+
+The `key` parameter may either be a `String` or a Node.js `Buffer` object and *may not* be zero-length.
 
 --------------------------------------------------------
 <a name="iterator_end"></a>
@@ -259,7 +262,7 @@ The callback will be called when the destroy operation is complete, with a possi
 
 > If a DB cannot be opened, you may attempt to call this method to resurrect as much of the contents of the database as possible. Some data may be lost, so be careful when calling this function on a database that contains important information.
 
-You will find information on the *repair* operation in the *LOG* file inside the store directory. 
+You will find information on the *repair* operation in the *LOG* file inside the store directory.
 
 A `repair()` can also be used to perform a compaction of the LevelDB log into table files.
 

--- a/iterator.js
+++ b/iterator.js
@@ -1,11 +1,13 @@
 const util             = require('util')
     , AbstractIterator = require('abstract-leveldown').AbstractIterator
     , fastFuture       = require('fast-future')
+    , compare          = require('ltgt').compare
 
 
 function Iterator (db, options) {
   AbstractIterator.call(this, db)
 
+  this.reverse    = options && options.reverse
   this.binding    = db.binding.iterator(options)
   this.cache      = null
   this.finished   = false
@@ -14,11 +16,32 @@ function Iterator (db, options) {
 
 util.inherits(Iterator, AbstractIterator)
 
-Iterator.prototype.seek = function (key) {
-  if (typeof key !== 'string')
-    throw new Error('seek requires a string key')
+Iterator.prototype.seek = function (target) {
+  if (this._ended)
+    throw new Error('cannot call seek() after end()')
+  if (this._nexting)
+    throw new Error('cannot call seek() before next() has completed')
+  if (typeof target !== 'string' && !Buffer.isBuffer(target))
+    throw new Error('seek() requires a string or buffer target')
+
+  // Check if target is cached
+  var length = this.cache ? this.cache.length : 0
+
+  if (length) {
+    if (typeof target === 'string') {
+      target = new Buffer(target)
+    }
+
+    for(var i=length-1; i>0; i-=2) {
+      var c = compare(this.cache[i], target)
+      if (this.reverse ? c <= 0 : c >= 0) {
+        return void this.cache.splice(i+1, length)
+      }
+    }
+  }
+
   this.cache = null
-  this.binding.seek(key)
+  this.binding.seek(target)
 }
 
 Iterator.prototype._next = function (callback) {

--- a/iterator.js
+++ b/iterator.js
@@ -19,12 +19,10 @@ Iterator.prototype.seek = function (key) {
     throw new Error('cannot call seek() after end()')
   if (this._nexting)
     throw new Error('cannot call seek() before next() has completed')
-  if (typeof key !== 'string' && !Buffer.isBuffer(key))
-    throw new Error('seek() requires a string or buffer key')
 
-  this.finished = false
   this.cache = null
   this.binding.seek(key)
+  this.finished = false
 }
 
 Iterator.prototype._next = function (callback) {

--- a/iterator.js
+++ b/iterator.js
@@ -1,7 +1,6 @@
 const util             = require('util')
     , AbstractIterator = require('abstract-leveldown').AbstractIterator
     , fastFuture       = require('fast-future')
-    , compare          = require('ltgt').compare
 
 
 function Iterator (db, options) {
@@ -24,22 +23,7 @@ Iterator.prototype.seek = function (target) {
   if (typeof target !== 'string' && !Buffer.isBuffer(target))
     throw new Error('seek() requires a string or buffer target')
 
-  // Check if target is cached
-  var length = this.cache ? this.cache.length : 0
-
-  if (length) {
-    if (typeof target === 'string') {
-      target = new Buffer(target)
-    }
-
-    for(var i=length-1; i>0; i-=2) {
-      var c = compare(this.cache[i], target)
-      if (this.reverse ? c <= 0 : c >= 0) {
-        return void this.cache.splice(i+1, length)
-      }
-    }
-  }
-
+  this.finished = false
   this.cache = null
   this.binding.seek(target)
 }

--- a/iterator.js
+++ b/iterator.js
@@ -6,7 +6,6 @@ const util             = require('util')
 function Iterator (db, options) {
   AbstractIterator.call(this, db)
 
-  this.reverse    = options && options.reverse
   this.binding    = db.binding.iterator(options)
   this.cache      = null
   this.finished   = false

--- a/iterator.js
+++ b/iterator.js
@@ -15,17 +15,17 @@ function Iterator (db, options) {
 
 util.inherits(Iterator, AbstractIterator)
 
-Iterator.prototype.seek = function (target) {
+Iterator.prototype.seek = function (key) {
   if (this._ended)
     throw new Error('cannot call seek() after end()')
   if (this._nexting)
     throw new Error('cannot call seek() before next() has completed')
-  if (typeof target !== 'string' && !Buffer.isBuffer(target))
-    throw new Error('seek() requires a string or buffer target')
+  if (typeof key !== 'string' && !Buffer.isBuffer(key))
+    throw new Error('seek() requires a string or buffer key')
 
   this.finished = false
   this.cache = null
-  this.binding.seek(target)
+  this.binding.seek(key)
 }
 
 Iterator.prototype._next = function (callback) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "delayed": "~1.0.1",
     "du": "~0.1.0",
     "faucet": "0.0.1",
+    "iota-array": "~1.0.0",
+    "lexicographic-integer": "~1.1.0",
     "mkfiletree": "~1.0.1",
     "monotonic-timestamp": "~0.0.8",
     "node-uuid": "~1.4.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "abstract-leveldown": "~2.4.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
-    "ltgt": "~2.1.2",
     "nan": "~2.2.0",
     "prebuild": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "abstract-leveldown": "~2.4.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
+    "ltgt": "~2.1.2",
     "nan": "~2.2.0",
     "prebuild": "^3.0.0"
   },

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -165,6 +165,15 @@ bool Iterator::OutOfRange (leveldb::Slice* target) {
   } else if (lte != NULL) {
     if (target->compare(*lte) > 0)
       return true;
+  } else if (start != NULL && reverse) {
+    if (target->compare(*start) > 0)
+      return true;
+  }
+
+  if (end != NULL) {
+    int d = target->compare(*end);
+    if (reverse ? d < 0 : d > 0)
+      return true;
   }
 
   if (gt != NULL) {
@@ -172,6 +181,9 @@ bool Iterator::OutOfRange (leveldb::Slice* target) {
       return true;
   } else if (gte != NULL) {
     if (target->compare(*gte) < 0)
+      return true;
+  } else if (start != NULL && !reverse) {
+    if (target->compare(*start) < 0)
       return true;
   }
 

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -270,15 +270,14 @@ NAN_METHOD(Iterator::Seek) {
   // release memory of previous target, in case next() wasn't called
   iterator->ReleaseTarget();
 
-  v8::Local<v8::Object> targetHandle = info[0].As<v8::Object>();
-
-  if (!node::Buffer::HasInstance(targetHandle) && !targetHandle->IsString())
+  if (!node::Buffer::HasInstance(info[0]) && !info[0]->IsString())
     return Nan::ThrowError("seek() requires a string or buffer key");
 
-  if (StringOrBufferLength(targetHandle) == 0)
+  if (StringOrBufferLength(info[0]) == 0)
     return Nan::ThrowError("cannot seek() to an empty key");
 
   // seek will be performed by NextWorker
+  v8::Local<v8::Object> targetHandle = info[0].As<v8::Object>();
   LD_STRING_OR_BUFFER_TO_SLICE(_target, targetHandle, target);
   iterator->target = new leveldb::Slice(_target.data(), _target.size());
 

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -90,19 +90,10 @@ void Iterator::IteratorSeek (leveldb::Slice* start) {
       } else {
         std::string key_ = dbIterator->key().ToString();
 
-        // in reverse, a manual seek should land on or before the target.
-        if (start->compare(key_) < 0) {
+        if (start->compare(key_) < 0)
           dbIterator->Prev();
-        } else if (lt != NULL) {
-          if (lt->compare(key_) <= 0)
-            dbIterator->Prev();
-        } else if (lte != NULL) {
-          if (lte->compare(key_) < 0)
-            dbIterator->Prev();
-        } else if (start != NULL) {
-          if (start->compare(key_))
-            dbIterator->Prev();
-        }
+        else if (lt != NULL && lt->compare(key_) <= 0)
+          dbIterator->Prev();
       }
 
       // TODO: what's the purpose of this? test suite passes without it

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -61,11 +61,12 @@ private:
   leveldb::Iterator* dbIterator;
   leveldb::ReadOptions* options;
   leveldb::Slice* start;
+  leveldb::Slice* target;
   std::string* end;
-  bool seeking;
   bool reverse;
   bool keys;
   bool values;
+  bool outOfRange;
   int limit;
   std::string* lt;
   std::string* lte;

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -86,6 +86,7 @@ private:
 
   bool Read (std::string& key, std::string& value);
   bool GetIterator ();
+  void IteratorSeek (leveldb::Slice* start);
 
   static NAN_METHOD(New);
   static NAN_METHOD(Seek);

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -54,6 +54,7 @@ public:
   leveldb::Status IteratorStatus ();
   void IteratorEnd ();
   void Release ();
+  void ReleaseTarget ();
 
 private:
   Database* database;
@@ -66,7 +67,6 @@ private:
   bool reverse;
   bool keys;
   bool values;
-  bool outOfRange;
   int limit;
   std::string* lt;
   std::string* lte;
@@ -84,10 +84,12 @@ public:
 
 private:
   Nan::Persistent<v8::Object> persistentHandle;
+  Nan::Persistent<v8::Object> persistentTargetHandle;
 
   bool Read (std::string& key, std::string& value);
   bool GetIterator ();
   void IteratorSeek (leveldb::Slice* start);
+  bool OutOfRange (leveldb::Slice* target);
 
   static NAN_METHOD(New);
   static NAN_METHOD(Seek);

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -69,6 +69,20 @@ make('iterator reverse seek in the middle', function (db, t, done) {
   })
 })
 
+make('iterator seek resets state', function(db, t, done) {
+  var ite = db.iterator()
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error from next()')
+    t.same(key.toString(), 'one', 'key matches')
+    t.ok(ite.cache, 'has cached items')
+    t.is(ite.finished, true, 'finished')
+    ite.seek('two')
+    t.notOk(ite.cache, 'cache is removed')
+    t.is(ite.finished, false, 'resets finished state')
+    done()
+  })
+})
+
 make('iterator seeks', function (db, t, done) {
   db.batch(pairs(10, { not: 7 }), function(err){
     t.error(err, 'no error from batch()')

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -28,23 +28,16 @@ make('iterator seek throws if key is not a string or buffer', function (db, t, d
 
 make('iterator is seekable', function (db, t, done) {
   var ite = db.iterator()
-  ite.seek('three')
+  ite.seek('two')
   ite.next(function (err, key, value) {
     t.error(err, 'no error from next()')
-    t.same(key.toString(), 'three', 'key matches')
-    t.same(value.toString(), '3', 'value matches')
-
+    t.same(key.toString(), 'two', 'key matches')
+    t.same(value.toString(), '2', 'value matches')
     ite.next(function (err, key, value) {
       t.error(err, 'no error from next()')
-      t.same(key.toString(), 'two', 'key matches')
-      t.same(value.toString(), '2', 'value matches')
-
-      ite.next(function (err, key, value) {
-        t.error(err, 'no error from next()')
-        t.same(key, undefined, 'end of iterator')
-        t.same(value, undefined, 'end of iterator')
-        ite.end(done)
-      })
+      t.same(key, undefined, 'end of iterator')
+      t.same(value, undefined, 'end of iterator')
+      ite.end(done)
     })
   })
 })

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -6,6 +6,7 @@ const test       = require('tape')
     , iota       = require('iota-array')
     , lexi       = require('lexicographic-integer')
     , util       = require('util')
+    , crypto     = require('crypto')
 
 abstract.all(leveldown, test, testCommon)
 
@@ -258,6 +259,27 @@ make('iterator seek respects range', function (db, t, done) {
       })
     }
   })
+})
+
+make('iterator seek memory release', function (db, t, done) {
+  var ite = db.iterator()
+  var rssBase = process.memoryUsage().rss
+
+  for(var i = 0; i < 1e4; i++) {
+    ite.seek(crypto.randomBytes(1024).toString('hex'))
+
+    if (i % 1000 === 0) {
+      if (typeof gc != 'undefined')
+        gc()
+      console.log('i = %d, rss = %s %s'
+        , i
+        , Math.round(process.memoryUsage().rss / rssBase * 100) + '%'
+        , Math.round(process.memoryUsage().rss / 1024 / 1024) + 'M'
+      )
+    }
+  }
+
+  ite.end(done)
 })
 
 function pairs (length, opts) {

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -320,6 +320,15 @@ make('iterator seek after end throws', function (db, t, done) {
   })
 })
 
+make('iterator seek to empty target throws', function (db, t, done) {
+  var ite = db.iterator()
+
+  t.throws(ite.seek.bind(ite, ''))
+  t.throws(ite.seek.bind(ite, Buffer(0)))
+
+  ite.end(done)
+})
+
 function pairs (length, opts) {
   opts = opts || {}
   return iota(length).filter(not(opts.not)).map(function (k) {

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -203,7 +203,7 @@ make('iterator seek lands on or after target', function(db, t, done) {
     }
 
     loop(db.iterator(), 0, cb)
-    loop(db.iterator({gt: '0a'}), 10, cb)
+    loop(db.iterator({gte: '0a'}), 10, cb)
     loop(db.iterator({highWaterMark: 1}), 0, cb)
 
     function loop(ite, i, done) {
@@ -230,7 +230,7 @@ make('iterator reverse seek lands on or before target', function(db, t, done) {
     }
 
     loop(db.iterator({reverse:true}), max, cb)
-    loop(db.iterator({reverse:true, lt: lexi.pack(90, 'hex')}), 90, cb)
+    loop(db.iterator({reverse:true, lte: lexi.pack(90, 'hex')}), 90, cb)
     loop(db.iterator({reverse:true, highWaterMark: 1}), max, cb)
 
     function loop(ite, i, done) {
@@ -251,13 +251,29 @@ make('iterator seek stays in range', function(db, t, done) {
 
     var pending = 0
 
-    expect({ gt: 5 }, 5, 6) // hm, should it?
-    expect({ gt: 5 }, 6, 6)
     expect({ gt: 5 }, 4, undefined)
+    expect({ gt: 5 }, 5, undefined)
+    expect({ gt: 5 }, 6, 6)
 
-    expect({ lt: 5 }, 5, undefined)
+    expect({ gte: 5 }, 4, undefined)
+    expect({ gte: 5 }, 5, 5)
+    expect({ gte: 5 }, 6, 6)
+
     expect({ lt: 5 }, 4, 4)
+    expect({ lt: 5 }, 5, undefined)
     expect({ lt: 5 }, 6, undefined)
+
+    expect({ lt: 5, reverse: true }, 4, 4)
+    expect({ lt: 5, reverse: true }, 5, undefined)
+    expect({ lt: 5, reverse: true }, 6, undefined)
+
+    expect({ lte: 5, reverse: true }, 4, 4)
+    expect({ lte: 5, reverse: true }, 5, 5)
+    expect({ lte: 5, reverse: true }, 6, undefined)
+
+    expect({ gt: 5, reverse: true }, 4, undefined)
+    expect({ gt: 5, reverse: true }, 5, undefined)
+    expect({ gt: 5, reverse: true }, 6, 6)
 
     function expect(range, target, expected) {
       var ite1 = create(range)
@@ -293,7 +309,7 @@ make('iterator seek stays in range', function(db, t, done) {
 
     function create(range) {
       pending++
-      var opts = { highWaterMark: 1 }
+      var opts = { highWaterMark: 1, reverse: !!range.reverse }
       if ('gt' in range) opts.gt = ''+range.gt
       if ('gte' in range) opts.gte = ''+range.gte
       if ('lt' in range) opts.lt = ''+range.lt

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -220,9 +220,21 @@ make('iterator seek respects range', function (db, t, done) {
     expect({ gte: '5' }, '5', '5')
     expect({ gte: '5' }, '6', '6')
 
+    expect({ start: '5' }, '4', undefined)
+    expect({ start: '5' }, '5', '5')
+    expect({ start: '5' }, '6', '6')
+
     expect({ lt: '5' }, '4', '4')
     expect({ lt: '5' }, '5', undefined)
     expect({ lt: '5' }, '6', undefined)
+
+    expect({ lte: '5' }, '4', '4')
+    expect({ lte: '5' }, '5', '5')
+    expect({ lte: '5' }, '6', undefined)
+
+    expect({ end: '5' }, '4', '4')
+    expect({ end: '5' }, '5', '5')
+    expect({ end: '5' }, '6', undefined)
 
     expect({ lt: '5', reverse: true }, '4', '4')
     expect({ lt: '5', reverse: true }, '5', undefined)
@@ -232,9 +244,26 @@ make('iterator seek respects range', function (db, t, done) {
     expect({ lte: '5', reverse: true }, '5', '5')
     expect({ lte: '5', reverse: true }, '6', undefined)
 
+    expect({ start: '5', reverse: true }, '4', '4')
+    expect({ start: '5', reverse: true }, '5', '5')
+    expect({ start: '5', reverse: true }, '6', undefined)
+
     expect({ gt: '5', reverse: true }, '4', undefined)
     expect({ gt: '5', reverse: true }, '5', undefined)
     expect({ gt: '5', reverse: true }, '6', '6')
+
+    expect({ gte: '5', reverse: true }, '4', undefined)
+    expect({ gte: '5', reverse: true }, '5', '5')
+    expect({ gte: '5', reverse: true }, '6', '6')
+
+    expect({ end: '5', reverse: true }, '4', undefined)
+    expect({ end: '5', reverse: true }, '5', '5')
+    expect({ end: '5', reverse: true }, '6', '6')
+
+    expect({ gt: '7', lt:'8' }, '7', undefined)
+    expect({ gte: '7', lt:'8' }, '7', '7')
+    expect({ gte: '7', lt:'8' }, '8', undefined)
+    expect({ gt: '7', lte:'8' }, '8', '8')
 
     function expect (range, target, expected) {
       pending++

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -10,12 +10,19 @@ const test       = require('tape')
 abstract.all(leveldown, test, testCommon)
 
 make('iterator seek throws if key is not a string or buffer', function (db, t, done) {
-  var keys = [void 0, 10, true, null]
+  var keys = [undefined, 10, true, null]
   var pending = keys.length
 
-  keys.forEach(function(key){
-    var ite = db.iterator(), error;
-    try { ite.seek(key) } catch (e) { error = e }
+  keys.forEach(function (key) {
+    var error
+    var ite = db.iterator()
+
+    try {
+      ite.seek(key)
+    } catch (e) {
+      error = e
+    }
+
     t.ok(error, 'had error from seek()')
     ite.end(end)
   })
@@ -30,11 +37,11 @@ make('iterator is seekable', function (db, t, done) {
   var ite = db.iterator()
   ite.seek('two')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
+    t.error(err, 'no error')
     t.same(key.toString(), 'two', 'key matches')
     t.same(value.toString(), '2', 'value matches')
     ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
+      t.error(err, 'no error')
       t.same(key, undefined, 'end of iterator')
       t.same(value, undefined, 'end of iterator')
       ite.end(done)
@@ -42,130 +49,14 @@ make('iterator is seekable', function (db, t, done) {
   })
 })
 
-make('iterator is seekable with buffer', function (db, t, done) {
-  var ite = db.iterator()
-  ite.seek(new Buffer('two'))
-  ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
-    t.same(key.toString(), 'two', 'key matches')
-    t.same(value.toString(), '2', 'value matches')
-    ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
-      t.same(key, undefined, 'end of iterator')
-      t.same(value, undefined, 'end of iterator')
-      ite.end(done)
-    })
-  })
-})
-
-make('iterator reverse seek in the middle', function (db, t, done) {
+make('reverse seek in the middle', function (db, t, done) {
   var ite = db.iterator({reverse: true, limit: 1})
   ite.seek('three!')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
+    t.error(err, 'no error')
     t.same(key.toString(), 'three', 'key matches')
     t.same(value.toString(), '3', 'value matches')
     ite.end(done)
-  })
-})
-
-make('iterator seek resets state', function(db, t, done) {
-  var ite = db.iterator()
-  ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
-    t.same(key.toString(), 'one', 'key matches')
-    t.ok(ite.cache, 'has cached items')
-    t.is(ite.finished, true, 'finished')
-    ite.seek('two')
-    t.notOk(ite.cache, 'cache is removed')
-    t.is(ite.finished, false, 'resets finished state')
-    done()
-  })
-})
-
-make('iterator seeks', function (db, t, done) {
-  db.batch(pairs(10, { not: 7 }), function(err){
-    t.error(err, 'no error from batch()')
-
-    var ite = db.iterator({gte: '4'})
-    ite.seek('5')
-    ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
-      t.same(key.toString(), '5', 'key matches')
-      t.same(value.toString(), '5', 'value matches')
-      ite.seek('7')
-      ite.next(function (err, key, value) {
-        t.error(err, 'no error from next()')
-        t.same(key && key.toString(), '8', 'key matches')
-        t.same(value && value.toString(), '8', 'value matches')
-        ite.end(done)
-      })
-    })
-  })
-})
-
-make('iterator seeks without cache', function (db, t, done) {
-  db.batch(pairs(10, { not: 7 }), function(err){
-    t.error(err, 'no error from batch()')
-
-    var ite = db.iterator({gte: '4', highWaterMark: 1})
-    ite.seek('5')
-    ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
-      t.is(ite.cache.length, 0, 'nothing cached')
-      t.same(key.toString(), '5', 'key matches')
-      t.same(value.toString(), '5', 'value matches')
-      ite.seek('7')
-      ite.next(function (err, key, value) {
-        t.error(err, 'no error from next()')
-        t.is(ite.cache.length, 0, 'nothing cached')
-        t.same(key && key.toString(), '8', 'key matches')
-        t.same(value && value.toString(), '8', 'value matches')
-        ite.end(done)
-      })
-    })
-  })
-})
-
-make('iterator reverse seeks', function (db, t, done) {
-  db.batch(pairs(10, { not: 5 }), function(err){
-    t.error(err, 'no error from batch()')
-
-    var ite = db.iterator({reverse: true, lte: '8'})
-    ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
-      t.same(key.toString(), '8', 'key matches')
-      t.same(value.toString(), '8', 'value matches')
-      ite.seek('5')
-      ite.next(function (err, key, value) {
-        t.error(err, 'no error from next()')
-        t.same(key.toString(), '4', 'key matches')
-        t.same(value.toString(), '4', 'value matches')
-        ite.end(done)
-      })
-    })
-  })
-})
-
-make('iterator reverse seeks without cache', function (db, t, done) {
-  db.batch(pairs(10, { not: 5 }), function(err){
-    t.error(err, 'no error from batch()')
-
-    var ite = db.iterator({reverse: true, lte: '8', highWaterMark: 1})
-    ite.next(function (err, key, value) {
-      t.error(err, 'no error from next()')
-      t.is(ite.cache.length, 0, 'nothing cached')
-      t.same(key.toString(), '8', 'key matches')
-      t.same(value.toString(), '8', 'value matches')
-      ite.seek('5')
-      ite.next(function (err, key, value) {
-        t.error(err, 'no error from next()')
-        t.is(ite.cache.length, 0, 'nothing cached')
-        t.same(key.toString(), '4', 'key matches')
-        t.same(value.toString(), '4', 'value matches')
-        ite.end(done)
-      })
-    })
   })
 })
 
@@ -173,31 +64,147 @@ make('iterator invalid seek', function (db, t, done) {
   var ite = db.iterator()
   ite.seek('zzz')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
+    t.error(err, 'no error')
     t.same(key, undefined, 'end of iterator')
     t.same(value, undefined, 'end of iterator')
     ite.end(done)
   })
 })
 
-make('iterator reverse seek from invalid range', function (db, t, done) {
+make('reverse seek from invalid range', function (db, t, done) {
   var ite = db.iterator({reverse: true})
   ite.seek('zzz')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error from next()')
+    t.error(err, 'no error')
     t.same(key.toString(), 'two', 'end of iterator')
     t.same(value.toString(), '2', 'end of iterator')
     ite.end(done)
   })
 })
 
-make('iterator seek lands on or after target', function(db, t, done) {
+make('iterator is seekable with buffer', function (db, t, done) {
+  var ite = db.iterator()
+  ite.seek(Buffer('two'))
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error from next()')
+    t.equal(key.toString(), 'two', 'key matches')
+    t.equal(value.toString(), '2', 'value matches')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error from next()')
+      t.equal(key, undefined, 'end of iterator')
+      t.equal(value, undefined, 'end of iterator')
+      ite.end(done)
+    })
+  })
+})
+
+make('iterator seek resets state', function (db, t, done) {
+  var ite = db.iterator()
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error from next()')
+    t.equal(key.toString(), 'one', 'key matches')
+    t.ok(ite.cache, 'has cached items')
+    t.equal(ite.finished, true, 'finished')
+    ite.seek('two')
+    t.notOk(ite.cache, 'cache is removed')
+    t.equal(ite.finished, false, 'resets finished state')
+    done()
+  })
+})
+
+make('iterator seeks', function (db, t, done) {
+  db.batch(pairs(10, { not: 7 }), function (err) {
+    t.error(err, 'no error from batch()')
+
+    var ite = db.iterator({gte: '4'})
+    ite.seek('5')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error from next()')
+      t.equal(key.toString(), '5', 'key matches')
+      t.equal(value.toString(), '5', 'value matches')
+      ite.seek('7')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error from next()')
+        t.equal(key.toString(), '8', 'key matches')
+        t.equal(value.toString(), '8', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('iterator seeks without cache', function (db, t, done) {
+  db.batch(pairs(10, { not: 7 }), function (err) {
+    t.error(err, 'no error from batch()')
+
+    var ite = db.iterator({gte: '4', highWaterMark: 1})
+    ite.seek('5')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error from next()')
+      t.equal(ite.cache.length, 0, 'nothing cached')
+      t.equal(key.toString(), '5', 'key matches')
+      t.equal(value.toString(), '5', 'value matches')
+      ite.seek('7')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error from next()')
+        t.equal(ite.cache.length, 0, 'nothing cached')
+        t.equal(key.toString(), '8', 'key matches')
+        t.equal(value.toString(), '8', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('iterator reverse seeks', function (db, t, done) {
+  db.batch(pairs(10, { not: 5 }), function (err) {
+    t.error(err, 'no error from batch()')
+
+    var ite = db.iterator({reverse: true, lte: '8'})
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error from next()')
+      t.equal(key.toString(), '8', 'key matches')
+      t.equal(value.toString(), '8', 'value matches')
+      ite.seek('5')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error from next()')
+        t.equal(key.toString(), '4', 'key matches')
+        t.equal(value.toString(), '4', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('iterator reverse seeks without cache', function (db, t, done) {
+  db.batch(pairs(10, { not: 5 }), function (err) {
+    t.error(err, 'no error from batch()')
+
+    var ite = db.iterator({reverse: true, lte: '8', highWaterMark: 1})
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error from next()')
+      t.equal(ite.cache.length, 0, 'nothing cached')
+      t.equal(key.toString(), '8', 'key matches')
+      t.equal(value.toString(), '8', 'value matches')
+      ite.seek('5')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error from next()')
+        t.equal(ite.cache.length, 0, 'nothing cached')
+        t.equal(key.toString(), '4', 'key matches')
+        t.equal(value.toString(), '4', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('iterator seek lands on or after target', function (db, t, done) {
   var max = 100, step = 15
-  db.batch(pairs(max, {lex: true, not: even}), function(err){
+  db.batch(pairs(max, {lex: true, not: even}), function (err) {
     t.error(err, 'no error from batch()')
 
     var pending = 3
-    var cb = function(err) {
+    var cb = function (err) {
       t.error(err, 'no error from end()')
       if (--pending === 0) done()
     }
@@ -211,20 +218,20 @@ make('iterator seek lands on or after target', function(db, t, done) {
       ite.seek(lexi.pack(i, 'hex'))
       ite.next(function (err, key, value) {
         var expected = even(i) ? i+1 : i
-        t.is(value && value.toString(), ''+expected, 'k'+expected)
+        t.equal(value.toString(), '' + expected, 'k' + expected)
         loop(ite, i+step, done)
       })
     }
   })
 })
 
-make('iterator reverse seek lands on or before target', function(db, t, done) {
+make('iterator reverse seek lands on or before target', function (db, t, done) {
   var max = 100, step = 15
-  db.batch(pairs(max, {lex: true, not: even}), function(err){
+  db.batch(pairs(max, {lex: true, not: even}), function (err) {
     t.error(err, 'no error from batch()')
 
     var pending = 3
-    var cb = function(err) {
+    var cb = function (err) {
       t.error(err, 'no error from end()')
       if (--pending === 0) done()
     }
@@ -238,100 +245,83 @@ make('iterator reverse seek lands on or before target', function(db, t, done) {
       ite.seek(lexi.pack(i, 'hex'))
       ite.next(function (err, key, value) {
         var expected = even(i) ? i-1 : i
-        t.is(value && value.toString(), ''+expected, 'k'+expected)
+        t.equal(value.toString(), '' + expected, 'k' + expected)
         loop(ite, i-step, done)
       })
     }
   })
 })
 
-make('iterator seek stays in range', function(db, t, done) {
-  db.batch(pairs(10), function(err){
+make('iterator seek stays in range', function (db, t, done) {
+  db.batch(pairs(10), function (err) {
     t.error(err, 'no error from batch()')
 
     var pending = 0
 
-    expect({ gt: 5 }, 4, undefined)
-    expect({ gt: 5 }, 5, undefined)
-    expect({ gt: 5 }, 6, 6)
+    expect({ gt: '5' }, '4', undefined)
+    expect({ gt: '5' }, '5', undefined)
+    expect({ gt: '5' }, '6', '6')
 
-    expect({ gte: 5 }, 4, undefined)
-    expect({ gte: 5 }, 5, 5)
-    expect({ gte: 5 }, 6, 6)
+    expect({ gte: '5' }, '4', undefined)
+    expect({ gte: '5' }, '5', '5')
+    expect({ gte: '5' }, '6', '6')
 
-    expect({ lt: 5 }, 4, 4)
-    expect({ lt: 5 }, 5, undefined)
-    expect({ lt: 5 }, 6, undefined)
+    expect({ lt: '5' }, '4', '4')
+    expect({ lt: '5' }, '5', undefined)
+    expect({ lt: '5' }, '6', undefined)
 
-    expect({ lt: 5, reverse: true }, 4, 4)
-    expect({ lt: 5, reverse: true }, 5, undefined)
-    expect({ lt: 5, reverse: true }, 6, undefined)
+    expect({ lt: '5', reverse: true }, '4', '4')
+    expect({ lt: '5', reverse: true }, '5', undefined)
+    expect({ lt: '5', reverse: true }, '6', undefined)
 
-    expect({ lte: 5, reverse: true }, 4, 4)
-    expect({ lte: 5, reverse: true }, 5, 5)
-    expect({ lte: 5, reverse: true }, 6, undefined)
+    expect({ lte: '5', reverse: true }, '4', '4')
+    expect({ lte: '5', reverse: true }, '5', '5')
+    expect({ lte: '5', reverse: true }, '6', undefined)
 
-    expect({ gt: 5, reverse: true }, 4, undefined)
-    expect({ gt: 5, reverse: true }, 5, undefined)
-    expect({ gt: 5, reverse: true }, 6, 6)
+    expect({ gt: '5', reverse: true }, '4', undefined)
+    expect({ gt: '5', reverse: true }, '5', undefined)
+    expect({ gt: '5', reverse: true }, '6', '6')
 
-    function expect(range, target, expected) {
-      var ite1 = create(range)
-      ite1.seek(''+target)
-      ite1.next(function(err, key, value) {
-        verify('initial seek', ite1, err, key, value)
-      })
+    function expect (range, target, expected) {
+      pending++
+      range.highWaterMark = 1
 
-      var ite2 = create(range)
-      ite2.next(function(err, key, value) {
-        t.error(err, 'no error from next()')
-        t.ok(key, 'has key')
-        ite2.seek(''+target)
-        ite2.next(function(err, key, value) {
-          verify('secondary seek', ite2, err, key, value)
-        })
-      })
+      var ite = db.iterator(range)
 
-      function verify(name, ite, err, key, value) {
+      ite.seek(target)
+      ite.next(function (err, key, value) {
         t.error(err, 'no error from next()')
 
-        var tpl = '%s(%d) on %s yields %s'
-        var msg = util.format(tpl, name, target, util.inspect(range), expected)
+        var tpl = 'seek(%s) on %s yields %s'
+        var msg = util.format(tpl, target, util.inspect(range), expected)
 
-        t.is(value ? value.toString() : ''+value, ''+expected, msg)
+        if (expected === undefined)
+          t.equal(value, undefined, msg)
+        else
+          t.equal(value.toString(), expected, msg)
 
-        ite.end(function end(err) {
+        ite.end(function (err) {
           t.error(err, 'no error from end()')
           if (!--pending) done()
         })
-      }
-    }
-
-    function create(range) {
-      pending++
-      var opts = { highWaterMark: 1, reverse: !!range.reverse }
-      if ('gt' in range) opts.gt = ''+range.gt
-      if ('gte' in range) opts.gte = ''+range.gte
-      if ('lt' in range) opts.lt = ''+range.lt
-      if ('lte' in range) opts.lte = ''+range.lte
-      return db.iterator(opts)
+      })
     }
   })
 })
 
-function pairs(length, opts) {
+function pairs (length, opts) {
   opts = opts || {}
-  return iota(length).filter(not(opts.not)).map(function(k){
-    var key = opts.lex ? lexi.pack(k, 'hex') : ''+k
-    return { type: opts.type || 'put', key: key, value: ''+k }
+  return iota(length).filter(not(opts.not)).map(function (k) {
+    var key = opts.lex ? lexi.pack(k, 'hex') : '' + k
+    return { type: 'put', key: key, value: '' + k }
   })
 }
 
-function not(n) {
-  if (typeof n === 'function') return function(k) { return !n(k) }
-  return function(k) { return k !== n }
+function not (n) {
+  if (typeof n === 'function') return function (k) { return !n(k) }
+  return function (k) { return k !== n }
 }
 
-function even(n) {
+function even (n) {
   return n % 2 === 0
 }

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -6,7 +6,7 @@ const test       = require('tape')
 
 abstract.all(leveldown, test, testCommon)
 
-make('iterator throws if key is not a string', function (db, t, done) {
+make('iterator throws if key is not a string or buffer', function (db, t, done) {
   var ite = db.iterator()
   var error
   try {
@@ -16,12 +16,35 @@ make('iterator throws if key is not a string', function (db, t, done) {
   }
 
   t.ok(error, 'had error')
-  t.end()
+  done()
 })
 
 make('iterator is seekable', function (db, t, done) {
   var ite = db.iterator()
-  ite.seek('two')
+  ite.seek('three')
+  ite.next(function (err, key, value) {
+    t.error(err, 'no error')
+    t.same(key.toString(), 'three', 'key matches')
+    t.same(value.toString(), '3', 'value matches')
+
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.same(key.toString(), 'two', 'key matches')
+      t.same(value.toString(), '2', 'value matches')
+
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error')
+        t.same(key, undefined, 'end of iterator')
+        t.same(value, undefined, 'end of iterator')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('iterator is seekable with buffer', function (db, t, done) {
+  var ite = db.iterator()
+  ite.seek(new Buffer('two'))
   ite.next(function (err, key, value) {
     t.error(err, 'no error')
     t.same(key.toString(), 'two', 'key matches')
@@ -43,6 +66,108 @@ make('reverse seek in the middle', function (db, t, done) {
     t.same(key.toString(), 'three', 'key matches')
     t.same(value.toString(), '3', 'value matches')
     ite.end(done)
+  })
+})
+
+make('multiple seeks', function (db, t, done) {
+  var ops = [0,1,2,3,4,5,6,8,9,10].reduce(function(a,k){
+    return a.push({ type: 'put', key: ''+k, value: ''+k }), a
+  }, [])
+
+  db.batch(ops, function(err){
+    t.error(err, 'no error')
+
+    var ite = db.iterator({gte: '4'})
+    ite.seek('5')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.same(key.toString(), '5', 'key matches')
+      t.same(value.toString(), '5', 'value matches')
+      ite.seek('7')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error')
+        t.same(key && key.toString(), '8', 'key matches')
+        t.same(value && value.toString(), '8', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('multiple seeks without cache', function (db, t, done) {
+  var ops = [0,1,2,3,4,5,6,8,9,10].reduce(function(a,k){
+    return a.push({ type: 'put', key: ''+k, value: ''+k }), a
+  }, [])
+
+  db.batch(ops, function(err){
+    t.error(err, 'no error')
+
+    var ite = db.iterator({gte: '4', highWaterMark: 1})
+    ite.seek('5')
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.is(ite.cache.length, 0, 'nothing cached')
+      t.same(key.toString(), '5', 'key matches')
+      t.same(value.toString(), '5', 'value matches')
+      ite.seek('7')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error')
+        t.is(ite.cache.length, 0, 'nothing cached')
+        t.same(key && key.toString(), '8', 'key matches')
+        t.same(value && value.toString(), '8', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('multiple reverse seeks', function (db, t, done) {
+  var ops = [0,1,2,3,4,6,7,8,9,10].reduce(function(a,k){
+    return a.push({ type: 'put', key: ''+k, value: ''+k }), a
+  }, [])
+
+  db.batch(ops, function(err){
+    t.error(err, 'no error')
+
+    var ite = db.iterator({reverse: true, lte: '8'})
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.same(key.toString(), '8', 'key matches')
+      t.same(value.toString(), '8', 'value matches')
+      ite.seek('5')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error')
+        t.same(key.toString(), '4', 'key matches')
+        t.same(value.toString(), '4', 'value matches')
+        ite.end(done)
+      })
+    })
+  })
+})
+
+make('multiple reverse seeks without cache', function (db, t, done) {
+  var ops = [0,1,2,3,4,6,7,8,9,10].reduce(function(a,k){
+    return a.push({ type: 'put', key: ''+k, value: ''+k }), a
+  }, [])
+
+  db.batch(ops, function(err){
+    t.error(err, 'no error')
+
+    var ite = db.iterator({reverse: true, lte: '8', highWaterMark: 1})
+    ite.next(function (err, key, value) {
+      t.error(err, 'no error')
+      t.is(ite.cache.length, 0, 'nothing cached')
+      t.same(key.toString(), '8', 'key matches')
+      t.same(value.toString(), '8', 'value matches')
+      ite.seek('5')
+      ite.next(function (err, key, value) {
+        t.error(err, 'no error')
+        t.is(ite.cache.length, 0, 'nothing cached')
+        t.same(key.toString(), '4', 'key matches')
+        t.same(value.toString(), '4', 'value matches')
+        ite.end(done)
+      })
+    })
   })
 })
 

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -311,6 +311,15 @@ make('iterator seek memory release', function (db, t, done) {
   ite.end(done)
 })
 
+make('iterator seek after end throws', function (db, t, done) {
+  var ite = db.iterator()
+  ite.end(function (err) {
+    t.error(err, 'no error from end()')
+    t.throws(ite.seek.bind(ite, 'one'))
+    done()
+  })
+})
+
 function pairs (length, opts) {
   opts = opts || {}
   return iota(length).filter(not(opts.not)).map(function (k) {

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -15,12 +15,12 @@ make('iterator seek throws if key is not a string or buffer', function (db, t, d
   keys.forEach(function(key){
     var ite = db.iterator(), error;
     try { ite.seek(key) } catch (e) { error = e }
-    t.ok(error, 'had error')
+    t.ok(error, 'had error from seek()')
     ite.end(end)
   })
 
   function end(err) {
-    t.error(err, 'no end error')
+    t.error(err, 'no error from end()')
     if (!--pending) done()
   }
 })
@@ -29,17 +29,17 @@ make('iterator is seekable', function (db, t, done) {
   var ite = db.iterator()
   ite.seek('three')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error')
+    t.error(err, 'no error from next()')
     t.same(key.toString(), 'three', 'key matches')
     t.same(value.toString(), '3', 'value matches')
 
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.same(key.toString(), 'two', 'key matches')
       t.same(value.toString(), '2', 'value matches')
 
       ite.next(function (err, key, value) {
-        t.error(err, 'no error')
+        t.error(err, 'no error from next()')
         t.same(key, undefined, 'end of iterator')
         t.same(value, undefined, 'end of iterator')
         ite.end(done)
@@ -52,11 +52,11 @@ make('iterator is seekable with buffer', function (db, t, done) {
   var ite = db.iterator()
   ite.seek(new Buffer('two'))
   ite.next(function (err, key, value) {
-    t.error(err, 'no error')
+    t.error(err, 'no error from next()')
     t.same(key.toString(), 'two', 'key matches')
     t.same(value.toString(), '2', 'value matches')
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.same(key, undefined, 'end of iterator')
       t.same(value, undefined, 'end of iterator')
       ite.end(done)
@@ -68,7 +68,7 @@ make('iterator reverse seek in the middle', function (db, t, done) {
   var ite = db.iterator({reverse: true, limit: 1})
   ite.seek('three!')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error')
+    t.error(err, 'no error from next()')
     t.same(key.toString(), 'three', 'key matches')
     t.same(value.toString(), '3', 'value matches')
     ite.end(done)
@@ -77,17 +77,17 @@ make('iterator reverse seek in the middle', function (db, t, done) {
 
 make('iterator seeks', function (db, t, done) {
   db.batch(pairs(10, { not: 7 }), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var ite = db.iterator({gte: '4'})
     ite.seek('5')
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.same(key.toString(), '5', 'key matches')
       t.same(value.toString(), '5', 'value matches')
       ite.seek('7')
       ite.next(function (err, key, value) {
-        t.error(err, 'no error')
+        t.error(err, 'no error from next()')
         t.same(key && key.toString(), '8', 'key matches')
         t.same(value && value.toString(), '8', 'value matches')
         ite.end(done)
@@ -98,18 +98,18 @@ make('iterator seeks', function (db, t, done) {
 
 make('iterator seeks without cache', function (db, t, done) {
   db.batch(pairs(10, { not: 7 }), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var ite = db.iterator({gte: '4', highWaterMark: 1})
     ite.seek('5')
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.is(ite.cache.length, 0, 'nothing cached')
       t.same(key.toString(), '5', 'key matches')
       t.same(value.toString(), '5', 'value matches')
       ite.seek('7')
       ite.next(function (err, key, value) {
-        t.error(err, 'no error')
+        t.error(err, 'no error from next()')
         t.is(ite.cache.length, 0, 'nothing cached')
         t.same(key && key.toString(), '8', 'key matches')
         t.same(value && value.toString(), '8', 'value matches')
@@ -121,16 +121,16 @@ make('iterator seeks without cache', function (db, t, done) {
 
 make('iterator reverse seeks', function (db, t, done) {
   db.batch(pairs(10, { not: 5 }), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var ite = db.iterator({reverse: true, lte: '8'})
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.same(key.toString(), '8', 'key matches')
       t.same(value.toString(), '8', 'value matches')
       ite.seek('5')
       ite.next(function (err, key, value) {
-        t.error(err, 'no error')
+        t.error(err, 'no error from next()')
         t.same(key.toString(), '4', 'key matches')
         t.same(value.toString(), '4', 'value matches')
         ite.end(done)
@@ -141,17 +141,17 @@ make('iterator reverse seeks', function (db, t, done) {
 
 make('iterator reverse seeks without cache', function (db, t, done) {
   db.batch(pairs(10, { not: 5 }), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var ite = db.iterator({reverse: true, lte: '8', highWaterMark: 1})
     ite.next(function (err, key, value) {
-      t.error(err, 'no error')
+      t.error(err, 'no error from next()')
       t.is(ite.cache.length, 0, 'nothing cached')
       t.same(key.toString(), '8', 'key matches')
       t.same(value.toString(), '8', 'value matches')
       ite.seek('5')
       ite.next(function (err, key, value) {
-        t.error(err, 'no error')
+        t.error(err, 'no error from next()')
         t.is(ite.cache.length, 0, 'nothing cached')
         t.same(key.toString(), '4', 'key matches')
         t.same(value.toString(), '4', 'value matches')
@@ -165,7 +165,7 @@ make('iterator invalid seek', function (db, t, done) {
   var ite = db.iterator()
   ite.seek('zzz')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error')
+    t.error(err, 'no error from next()')
     t.same(key, undefined, 'end of iterator')
     t.same(value, undefined, 'end of iterator')
     ite.end(done)
@@ -176,7 +176,7 @@ make('iterator reverse seek from invalid range', function (db, t, done) {
   var ite = db.iterator({reverse: true})
   ite.seek('zzz')
   ite.next(function (err, key, value) {
-    t.error(err, 'no error')
+    t.error(err, 'no error from next()')
     t.same(key.toString(), 'two', 'end of iterator')
     t.same(value.toString(), '2', 'end of iterator')
     ite.end(done)
@@ -186,11 +186,11 @@ make('iterator reverse seek from invalid range', function (db, t, done) {
 make('iterator seek lands on or after target', function(db, t, done) {
   var max = 100, step = 15
   db.batch(pairs(max, {lex: true, not: even}), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var pending = 3
     var cb = function(err) {
-      t.error(err, 'no end error')
+      t.error(err, 'no error from end()')
       if (--pending === 0) done()
     }
 
@@ -213,11 +213,11 @@ make('iterator seek lands on or after target', function(db, t, done) {
 make('iterator reverse seek lands on or before target', function(db, t, done) {
   var max = 100, step = 15
   db.batch(pairs(max, {lex: true, not: even}), function(err){
-    t.error(err, 'no error')
+    t.error(err, 'no error from batch()')
 
     var pending = 3
     var cb = function(err) {
-      t.error(err, 'no end error')
+      t.error(err, 'no error from end()')
       if (--pending === 0) done()
     }
 


### PR DESCRIPTION
This PR enables multiple calls to `iterator.seek(target)` while iterating, and adds support for Buffer keys. The primary use case is [skip scanning](https://oracle-base.com/articles/9i/index-skip-scanning).

``` js
iter.next(function(err,key,value){
  if (key.toString() === 'a') {
    iter.seek('g')
    iter.next(etc)
  }
})
```

I renamed the variable `key` to `target`, because it better expresses the fact that it's not an exact match.

Like before, `seek()` respects the iterator direction (reverse or not), which differs from the native LevelDB seek behavior. The native seek lands on or _after_ a target, but in leveldown, if reverse is true, it lands on or _before_ the target (at least it should, breaking test cases are welcome).

It also accounts for keys in the cache. If one of those matches the target, no native seek is performed. Instead, the cache is truncated so that the following `next()` yields the target key.

Note I'm not a C++ guy, and this PR is bigger than I intended. But what I basically did, is move the initial seek in `GetIterator()` to a separate private function (`IteratorSeek`) so that both `GetIterator` (for the regular initial seek) and `Seek` can use it.
