### PR TITLE
gitignore release folder for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 build/
 build-pre-gyp/
+Release/
 libleveldb.so
 libleveldb.a
 leakydb


### PR DESCRIPTION
To clean up PR #256, this one adds the "Release" folder to `.gitignore`. Because on Windows, the build creates these two:

- deps/leveldb/Release/
- deps/snappy/Release/