### PR TITLE
Fix several memory leaks in workers

### DIFF
--- a/src/batch_async.cc
+++ b/src/batch_async.cc
@@ -19,7 +19,10 @@ BatchWriteWorker::BatchWriteWorker (
   , batch(batch)
 {};
 
-BatchWriteWorker::~BatchWriteWorker () {}
+BatchWriteWorker::~BatchWriteWorker () {
+  delete callback;
+  callback = NULL;
+}
 
 void BatchWriteWorker::Execute () {
   SetStatus(batch->Write());

--- a/src/common.h
+++ b/src/common.h
@@ -13,6 +13,7 @@ namespace leveldown {
 NAN_INLINE bool BooleanOptionValue(v8::Local<v8::Object> options,
                                    const char* _key,
                                    bool def = false) {
+  Nan::HandleScope scope;
   v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
   return !options.IsEmpty()
     && options->Has(key)
@@ -23,6 +24,7 @@ NAN_INLINE bool BooleanOptionValue(v8::Local<v8::Object> options,
 NAN_INLINE uint32_t UInt32OptionValue(v8::Local<v8::Object> options,
                                       const char* _key,
                                       uint32_t def) {
+  Nan::HandleScope scope;
   v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
   return !options.IsEmpty()
     && options->Has(key)

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -48,6 +48,8 @@ OpenWorker::OpenWorker (
 
 OpenWorker::~OpenWorker () {
   delete options;
+  delete callback;
+  callback = NULL;
 }
 
 void OpenWorker::Execute () {
@@ -62,7 +64,10 @@ CloseWorker::CloseWorker (
 ) : AsyncWorker(database, callback)
 {};
 
-CloseWorker::~CloseWorker () {}
+CloseWorker::~CloseWorker () {
+  delete callback;
+  callback = NULL;
+}
 
 void CloseWorker::Execute () {
   database->CloseDatabase();
@@ -71,8 +76,6 @@ void CloseWorker::Execute () {
 void CloseWorker::WorkComplete () {
   Nan::HandleScope scope;
   HandleOKCallback();
-  delete callback;
-  callback = NULL;
 }
 
 /** IO WORKER (abstract) **/
@@ -120,6 +123,8 @@ ReadWorker::ReadWorker (
 
 ReadWorker::~ReadWorker () {
   delete options;
+  delete callback;
+  callback = NULL;
 }
 
 void ReadWorker::Execute () {
@@ -164,6 +169,8 @@ DeleteWorker::DeleteWorker (
 
 DeleteWorker::~DeleteWorker () {
   delete options;
+  delete callback;
+  callback = NULL;
 }
 
 void DeleteWorker::Execute () {
@@ -218,6 +225,8 @@ BatchWorker::BatchWorker (
 BatchWorker::~BatchWorker () {
   delete batch;
   delete options;
+  delete callback;
+  callback = NULL;
 }
 
 void BatchWorker::Execute () {
@@ -242,7 +251,10 @@ ApproximateSizeWorker::ApproximateSizeWorker (
   SaveToPersistent("end", endHandle);
 };
 
-ApproximateSizeWorker::~ApproximateSizeWorker () {}
+ApproximateSizeWorker::~ApproximateSizeWorker () {
+  delete callback;
+  callback = NULL;
+}
 
 void ApproximateSizeWorker::Execute () {
   size = database->ApproximateSizeFromDatabase(&range);

--- a/src/iterator_async.cc
+++ b/src/iterator_async.cc
@@ -24,7 +24,10 @@ NextWorker::NextWorker (
   , localCallback(localCallback)
 {};
 
-NextWorker::~NextWorker () {}
+NextWorker::~NextWorker () {
+  delete callback;
+  callback = NULL;
+}
 
 void NextWorker::Execute () {
   ok = iterator->IteratorNext(result);
@@ -33,6 +36,8 @@ void NextWorker::Execute () {
 }
 
 void NextWorker::HandleOKCallback () {
+  Nan::HandleScope scope;
+
   size_t idx = 0;
 
   size_t arraySize = result.size() * 2;
@@ -85,7 +90,10 @@ EndWorker::EndWorker (
   , iterator(iterator)
 {};
 
-EndWorker::~EndWorker () { }
+EndWorker::~EndWorker () {
+  delete callback;
+  callback = NULL;
+}
 
 void EndWorker::Execute () {
   iterator->IteratorEnd();

--- a/src/leveldown_async.cc
+++ b/src/leveldown_async.cc
@@ -21,6 +21,8 @@ DestroyWorker::DestroyWorker (
 
 DestroyWorker::~DestroyWorker () {
   delete location;
+  delete callback;
+  callback = NULL;
 }
 
 void DestroyWorker::Execute () {
@@ -39,6 +41,8 @@ RepairWorker::RepairWorker (
 
 RepairWorker::~RepairWorker () {
   delete location;
+  delete callback;
+  callback = NULL;
 }
 
 void RepairWorker::Execute () {


### PR DESCRIPTION
Using these changes with my own very simple leveldown wrapper instead of levelup solved my memory issues (I think it's maybe mostly the wrapper. I'm not sure what funky thing levelup is doing to cause so much mem usage on the native heap. Maybe holding a reference to my Buffers or something?).

Anyway, it's pretty hard to overstate what a difference these changes have made. At height 180k of my blockchain sync my process' memory usage used to be somewhere around 1.7gb. Now it's around __100mb__.

Is there a reason these callbacks weren't getting freed up? I figure they are supposed to be freed up since I'm not getting any core dump scolding me about double free() calls. Nothing else seems to be freeing them up.

There was also a missing HandleScope in the Iterator worker's HandleOkCallback where Strings and Buffers were being allocated for v8. I'm guessing that may have been causing issues.

cc @rvagg @ralphtheninja