### PR TITLE
Memleak fix (again)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -13,6 +13,7 @@ namespace leveldown {
 NAN_INLINE bool BooleanOptionValue(v8::Local<v8::Object> options,
                                    const char* _key,
                                    bool def = false) {
+  Nan::HandleScope scope;
   v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
   return !options.IsEmpty()
     && options->Has(key)
@@ -23,6 +24,7 @@ NAN_INLINE bool BooleanOptionValue(v8::Local<v8::Object> options,
 NAN_INLINE uint32_t UInt32OptionValue(v8::Local<v8::Object> options,
                                       const char* _key,
                                       uint32_t def) {
+  Nan::HandleScope scope;
   v8::Local<v8::String> key = Nan::New(_key).ToLocalChecked();
   return !options.IsEmpty()
     && options->Has(key)

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -76,6 +76,14 @@ Iterator::~Iterator () {
     delete start;
   if (end != NULL)
     delete end;
+  if (lt != NULL)
+    delete lt;
+  if (gt != NULL)
+    delete gt;
+  if (lte != NULL)
+    delete lte;
+  if (gte != NULL)
+    delete gte;
 };
 
 bool Iterator::GetIterator () {

--- a/src/iterator_async.cc
+++ b/src/iterator_async.cc
@@ -33,6 +33,7 @@ void NextWorker::Execute () {
 }
 
 void NextWorker::HandleOKCallback () {
+  Nan::HandleScope scope;
   size_t idx = 0;
 
   size_t arraySize = result.size() * 2;


### PR DESCRIPTION
Adds missing handlescopes and frees up lte/gte/lt/gt strings on iterator destruction. Seems to improve my mem usage with iterators, as far as I can tell.

cc @rvagg @ralphtheninja 