### PR TITLE
iterator: do not cast undefined option values to 0.

### DIFF
--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -397,12 +397,14 @@ NAN_METHOD(Iterator::New) {
       }
     }
 
-    if (!optionsObj.IsEmpty() && optionsObj->Has(Nan::New("limit").ToLocalChecked())) {
+    if (optionsObj->Has(Nan::New("limit").ToLocalChecked())
+        && optionsObj->Get(Nan::New("limit").ToLocalChecked())->IsNumber()) {
       limit = v8::Local<v8::Integer>::Cast(optionsObj->Get(
           Nan::New("limit").ToLocalChecked()))->Value();
     }
 
-    if (optionsObj->Has(Nan::New("highWaterMark").ToLocalChecked())) {
+    if (optionsObj->Has(Nan::New("highWaterMark").ToLocalChecked())
+        && optionsObj->Get(Nan::New("highWaterMark").ToLocalChecked())->IsNumber()) {
       highWaterMark = v8::Local<v8::Integer>::Cast(optionsObj->Get(
             Nan::New("highWaterMark").ToLocalChecked()))->Value();
     }


### PR DESCRIPTION
Iterator option parsing currently casts `limit=undefined` to `limit=0`. It's really frustrating to debug if you're not aware of it. 

``` js
function iterate(options, callback) {
  var iter = db.iterator({
    gte: options.gte,
    lte: options.lte,
    limit: options.limit
  });
  ...
}

// Always yields 0 results.
iterate({ gte: 'bar', lte: 'foo' }, callback);
```

This PR checks types beforehand.
