### PR TITLE
upgrade nan, remove Function::NewInstance() deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "abstract-leveldown": "~2.4.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
-    "nan": "~2.3.0",
+    "nan": "~2.4.0",
     "prebuild": "^4.1.1"
   },
   "devDependencies": {

--- a/src/batch.cc
+++ b/src/batch.cc
@@ -61,6 +61,7 @@ v8::Local<v8::Value> Batch::NewInstance (
 
   Nan::EscapableHandleScope scope;
 
+  Nan::MaybeLocal<v8::Object> maybeInstance;
   v8::Local<v8::Object> instance;
 
   v8::Local<v8::FunctionTemplate> constructorHandle =
@@ -68,12 +69,16 @@ v8::Local<v8::Value> Batch::NewInstance (
 
   if (optionsObj.IsEmpty()) {
     v8::Local<v8::Value> argv[1] = { database };
-    instance = constructorHandle->GetFunction()->NewInstance(1, argv);
+    maybeInstance = Nan::NewInstance(constructorHandle->GetFunction(), 1, argv);
   } else {
     v8::Local<v8::Value> argv[2] = { database, optionsObj };
-    instance = constructorHandle->GetFunction()->NewInstance(2, argv);
+    maybeInstance = Nan::NewInstance(constructorHandle->GetFunction(), 2, argv);
   }
 
+  if (maybeInstance.IsEmpty())
+      Nan::ThrowError("Could not create new Batch instance");
+  else
+    instance = maybeInstance.ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/src/database.cc
+++ b/src/database.cc
@@ -157,14 +157,19 @@ NAN_METHOD(Database::New) {
 v8::Local<v8::Value> Database::NewInstance (v8::Local<v8::String> &location) {
   Nan::EscapableHandleScope scope;
 
+  Nan::MaybeLocal<v8::Object> maybeInstance;
   v8::Local<v8::Object> instance;
 
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New<v8::FunctionTemplate>(database_constructor);
 
   v8::Local<v8::Value> argv[] = { location };
-  instance = constructorHandle->GetFunction()->NewInstance(1, argv);
+  maybeInstance = Nan::NewInstance(constructorHandle->GetFunction(), 1, argv);
 
+  if (maybeInstance.IsEmpty())
+      Nan::ThrowError("Could not create new Database instance");
+  else
+    instance = maybeInstance.ToLocalChecked();
   return scope.Escape(instance);
 }
 
@@ -455,7 +460,7 @@ NAN_METHOD(Database::Iterator) {
   // each iterator gets a unique id for this Database, so we can
   // easily store & lookup on our `iterators` map
   uint32_t id = database->currentIteratorId++;
-  v8::TryCatch try_catch;
+  Nan::TryCatch try_catch;
   v8::Local<v8::Object> iteratorHandle = Iterator::NewInstance(
       info.This()
     , Nan::New<v8::Number>(id)

--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -322,18 +322,23 @@ v8::Local<v8::Object> Iterator::NewInstance (
 
   Nan::EscapableHandleScope scope;
 
+  Nan::MaybeLocal<v8::Object> maybeInstance;
   v8::Local<v8::Object> instance;
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New<v8::FunctionTemplate>(iterator_constructor);
 
   if (optionsObj.IsEmpty()) {
     v8::Local<v8::Value> argv[2] = { database, id };
-    instance = constructorHandle->GetFunction()->NewInstance(2, argv);
+    maybeInstance = Nan::NewInstance(constructorHandle->GetFunction(), 2, argv);
   } else {
     v8::Local<v8::Value> argv[3] = { database, id, optionsObj };
-    instance = constructorHandle->GetFunction()->NewInstance(3, argv);
+    maybeInstance = Nan::NewInstance(constructorHandle->GetFunction(), 3, argv);
   }
 
+  if (maybeInstance.IsEmpty())
+      Nan::ThrowError("Could not create new Iterator instance");
+  else
+    instance = maybeInstance.ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/iterator-recursion-test.js
+++ b/test/iterator-recursion-test.js
@@ -21,13 +21,6 @@ var db
 
 test('setUp common', testCommon.setUp)
 
-test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
-  db.open(function () {
-    db.batch(sourceData, t.end.bind(t))
-  })
-})
-
 test('try to create an iterator with a blown stack', function (t) {
   // Reducing the stack size down from the default 984 for the child node
   // process makes it easier to trigger the bug condition. But making it too low
@@ -44,6 +37,14 @@ test('try to create an iterator with a blown stack', function (t) {
 
   child.on('exit', function (code, sig) {
     t.equal(code, 0, 'child exited normally')
+  })
+})
+
+test('setUp db', function (t) {
+  db = leveldown(testCommon.location())
+  db.open(function (err) {
+    t.error(err)
+    db.batch(sourceData, t.end.bind(t))
   })
 })
 


### PR DESCRIPTION
builds on the leveldb-1.19 branch, gets rid of warnings you'll see when using Node v6+

_because moar monads_