### PR TITLE
CI with prebuilds for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ LevelDOWN
 **A Low-level Node.js LevelDB binding**
 
 [![Build Status](https://secure.travis-ci.org/Level/leveldown.png)](http://travis-ci.org/Level/leveldown)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/Level/leveldown.svg)](https://ci.appveyor.com/project/Level/leveldown)
 [![dependencies](https://david-dm.org/Level/leveldown.svg)](https://david-dm.org/level/leveldown)
 
 [![NPM](https://nodei.co/npm/leveldown.png?stars&downloads&downloadRank)](https://nodei.co/npm/leveldown/) [![NPM](https://nodei.co/npm-dl/leveldown.png?months=6&height=3)](https://nodei.co/npm/leveldown/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: "{build}"
+build: off
+shallow_clone: true
+skip_tags: true
+
+environment:
+  matrix:
+    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+
+platform:
+  - x86
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm -g i npm@latest
+  - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
+  - npm i --ignore-scripts
+  - for /f %%i in ('node -v') do set exact_nodejs_version=%%i
+  - prebuild -b %exact_nodejs_version% --strip
+
+test_script:
+  - npm test
+
+on_success:
+  - for %%i in (prebuilds\*) do appveyor PushArtifact %%i


### PR DESCRIPTION
This AppVeyor configuration runs unit tests and produces prebuilds for each commit. Tagged commits trigger an upload to GitHub.

Which means the AppVeyor job will be the first to create a GH release, whenever someone pushes a tag. Does anyone foresee problems with that? Alternatively, we can manually download artifacts from AppVeyor and attach them to a GH release. WDYT?

See [this dummy project](https://github.com/vweevers/auto-prebuild) and its [artifacts](https://ci.appveyor.com/project/vweevers/auto-prebuild/build/8/job/2rrju0tby68fhaim/artifacts) as an example.

Tackles #305 and https://github.com/Level/leveldown/issues/288#issuecomment-243664265.

Tasks:
- [x] Create [organizational account owner](https://www.appveyor.com/docs/team-setup/#setting-up-appveyor-account-for-github-organization) (**which email address?**)
- [ ] Add collaborators (**who is interested?**) as administrators
- [x] ~~Add GH token secret to `appveyor.yml`~~
- [x] Write [a tool](https://github.com/vweevers/apv) to trigger builds for previous commits. Then we can make Windows prebuilds retroactively: `apv build 3e9d9468 --account level --project leveldown`
