### PR TITLE
add prebuild-ci

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 version: "{build}"
 build: off
-shallow_clone: true
 skip_tags: true
 
 environment:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "monotonic-timestamp": "~0.0.8",
     "node-uuid": "~1.4.3",
     "optimist": "~0.6.1",
+    "prebuild-ci": "^1.0.9",
     "readfiletree": "~0.0.1",
     "rimraf": "~2.5.0",
     "slump": "~2.0.0",
@@ -50,7 +51,7 @@
   },
   "scripts": {
     "install": "prebuild --install",
-    "test": "tape test/*-test.js | faucet",
+    "test": "(tape test/*-test.js | faucet) && prebuild-ci",
     "rebuild": "prebuild --compile",
     "prebuild": "prebuild --all --strip --verbose"
   },


### PR DESCRIPTION
This will make it so on every publish commit CI will upload the prebuilds to GitHub releases, so there's going to be automatic prebuilds for all OS / Node combinations we support, without manual work necessary.