### PR TITLE
250x faster iterator seek

### DIFF
--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -58,6 +58,7 @@ Iterator::Iterator (
   count      = 0;
   target     = NULL;
   seeking    = false;
+  landed     = false;
   nexting    = false;
   ended      = false;
   endWorker  = NULL;
@@ -215,6 +216,11 @@ bool Iterator::IteratorNext (std::vector<std::pair<std::string, std::string> >& 
       result.push_back(std::make_pair(key, value));
       size = size + key.size() + value.size();
 
+      if (!landed) {
+        landed = true;
+        return true;
+      }
+
       if (size > highWaterMark)
         return true;
 
@@ -273,6 +279,7 @@ NAN_METHOD(Iterator::Seek) {
 
   dbIterator->Seek(*iterator->target);
   iterator->seeking = true;
+  iterator->landed = false;
 
   if (iterator->OutOfRange(iterator->target)) {
     if (iterator->reverse) {

--- a/src/iterator.h
+++ b/src/iterator.h
@@ -64,6 +64,7 @@ private:
   leveldb::Slice* target;
   std::string* end;
   bool seeking;
+  bool landed;
   bool reverse;
   bool keys;
   bool values;


### PR DESCRIPTION
Sorry for the scary title, but I'm not kidding! 🤓

Benchmarks first (on my MacBook @ 1.2 GHz Intel Core M):
```
SCAN: 5147.625ms
SKIP: 9171.527ms

SCAN_NEW: 5143.952ms
SKIP_NEW: 36.186ms
```

@kesla s amazing https://github.com/Level/leveldown/pull/96 brought super fast read streams, but I see some modules using something like:

```javascript
function fuzzyGet (gt, lt){
	db.createReadStream({
		gt: gt,
		lt: lt,
		limit: 1
	}).on(...)
}
```

The buffering mechanism is wasting IO in this use case.

I want to keep the good parts of both worlds, so I've added a new `bool landed` to iterator, and let it **ignore  highWaterMark for once** after seeking:

![2016-12-19 12 14 48](https://cloud.githubusercontent.com/assets/219051/21301352/b89e2a84-c5e7-11e6-852e-5cea02f78ec6.png)

Now we can do really really fast **skip scan**, **sorted set intersection** and **K-way merging**, with multiple seeks from https://github.com/Level/leveldown/pull/323.

This change is transparent to levelup and users, and will not affect normal iterating without `iterator.seek`.