### PR TITLE
Expose `database#compactRange(start, end, callback)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ The `callback` function will be called with no arguments if the operation is suc
 
 
 --------------------------------------------------------
+<a name="leveldown_compactRange"></a>
+### leveldown#compactRange(start, end, callback)
+<code>compactRange()</code> is an instance method on an existing database object. Used to manually trigger a database compaction in the range `[start..end)`.
+
+The `start` and `end` parameters may be either `String` or Node.js `Buffer` objects representing keys in the LevelDB store.
+
+The `callback` function will be called with no arguments if the operation is successful or with a single `error` argument if the operation failed for any reason.
+
+
+--------------------------------------------------------
 <a name="leveldown_getProperty"></a>
 ### leveldown#getProperty(property)
 <code>getProperty</code> can be used to get internal details from LevelDB. When issued with a valid property string, a readable string will be returned (this method is synchronous).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Tested & supported platforms
   * <a href="#leveldown_del"><code><b>leveldown#del()</b></code></a>
   * <a href="#leveldown_batch"><code><b>leveldown#batch()</b></code></a>
   * <a href="#leveldown_approximateSize"><code><b>leveldown#approximateSize()</b></code></a>
+  * <a href="#leveldown_compactRange"><code><b>leveldown#compactRange()</b></code></a>
   * <a href="#leveldown_getProperty"><code><b>leveldown#getProperty()</b></code></a>
   * <a href="#leveldown_iterator"><code><b>leveldown#iterator()</b></code></a>
   * <a href="#iterator_next"><code><b>iterator#next()</b></code></a>

--- a/leveldown.js
+++ b/leveldown.js
@@ -58,6 +58,11 @@ LevelDOWN.prototype._approximateSize = function (start, end, callback) {
 }
 
 
+LevelDOWN.prototype.compactRange = function (start, end, callback) {
+  this.binding.compactRange(start, end, callback)
+}
+
+
 LevelDOWN.prototype.getProperty = function (property) {
   if (typeof property != 'string')
     throw new Error('getProperty() requires a valid `property` argument')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "Anton Whalley <anton.whalley@nearform.com> (https://github.com/No9)",
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)",
     "Pedro Teixeira <pedro.teixeira@gmail.com> (https://github.com/pgte)",
-    "James Halliday <mail@substack.net> (https://github.com/substack)"
+    "James Halliday <mail@substack.net> (https://github.com/substack)",
+    "Gordon Hall <gordonh@member.fsf.org> (https://github.com/bookchin)"
   ],
   "repository": {
     "type": "git",

--- a/src/database.cc
+++ b/src/database.cc
@@ -441,7 +441,6 @@ NAN_METHOD(Database::CompactRange) {
   v8::Local<v8::Object> endHandle = info[1].As<v8::Object>();
 
   LD_METHOD_SETUP_COMMON(compactRange, -1, 2)
-
   LD_STRING_OR_BUFFER_TO_SLICE(start, startHandle, start)
   LD_STRING_OR_BUFFER_TO_SLICE(end, endHandle, end)
 

--- a/src/database.h
+++ b/src/database.h
@@ -68,6 +68,7 @@ public:
     , leveldb::WriteBatch* batch
   );
   uint64_t ApproximateSizeFromDatabase (const leveldb::Range* range);
+  void CompactRangeFromDatabase (const leveldb::Slice* start, const leveldb::Slice* end);
   void GetPropertyFromDatabase (const leveldb::Slice& property, std::string* value);
   leveldb::Iterator* NewIterator (leveldb::ReadOptions* options);
   const leveldb::Snapshot* NewSnapshot ();
@@ -101,6 +102,7 @@ private:
   static NAN_METHOD(Write);
   static NAN_METHOD(Iterator);
   static NAN_METHOD(ApproximateSize);
+  static NAN_METHOD(CompactRange);
   static NAN_METHOD(GetProperty);
 };
 

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -280,21 +280,24 @@ CompactRangeWorker::CompactRangeWorker (
 {
   Nan::HandleScope scope;
 
-  SaveToPersistent("start", startHandle);
-  SaveToPersistent("end", endHandle);
+  rangeStart = start;
+  rangeEnd = end;
+
+  SaveToPersistent("compactStart", startHandle);
+  SaveToPersistent("compactEnd", endHandle);
 };
 
 CompactRangeWorker::~CompactRangeWorker () {}
 
 void CompactRangeWorker::Execute () {
-  database->CompactRangeFromDatabase(&start, &end);
+  database->CompactRangeFromDatabase(&rangeStart, &rangeEnd);
 }
 
 void CompactRangeWorker::WorkComplete() {
   Nan::HandleScope scope;
 
-  DisposeStringOrBufferFromSlice(GetFromPersistent("start"), start);
-  DisposeStringOrBufferFromSlice(GetFromPersistent("end"), end);
+  DisposeStringOrBufferFromSlice(GetFromPersistent("compactStart"), rangeStart);
+  DisposeStringOrBufferFromSlice(GetFromPersistent("compactEnd"), rangeEnd);
   AsyncWorker::WorkComplete();
 }
 

--- a/src/database_async.cc
+++ b/src/database_async.cc
@@ -267,4 +267,44 @@ void ApproximateSizeWorker::HandleOKCallback () {
   callback->Call(2, argv);
 }
 
+/** COMPACT RANGE WORKER **/
+
+CompactRangeWorker::CompactRangeWorker (
+    Database *database
+  , Nan::Callback *callback
+  , leveldb::Slice start
+  , leveldb::Slice end
+  , v8::Local<v8::Object> &startHandle
+  , v8::Local<v8::Object> &endHandle
+) : AsyncWorker(database, callback)
+{
+  Nan::HandleScope scope;
+
+  SaveToPersistent("start", startHandle);
+  SaveToPersistent("end", endHandle);
+};
+
+CompactRangeWorker::~CompactRangeWorker () {}
+
+void CompactRangeWorker::Execute () {
+  database->CompactRangeFromDatabase(&start, &end);
+}
+
+void CompactRangeWorker::WorkComplete() {
+  Nan::HandleScope scope;
+
+  DisposeStringOrBufferFromSlice(GetFromPersistent("start"), start);
+  DisposeStringOrBufferFromSlice(GetFromPersistent("end"), end);
+  AsyncWorker::WorkComplete();
+}
+
+void CompactRangeWorker::HandleOKCallback () {
+  Nan::HandleScope scope;
+
+  v8::Local<v8::Value> argv[] = {
+      Nan::Null()
+  };
+  callback->Call(1, argv);
+}
+
 } // namespace leveldown

--- a/src/database_async.h
+++ b/src/database_async.h
@@ -162,6 +162,28 @@ public:
     uint64_t size;
 };
 
+class CompactRangeWorker : public AsyncWorker {
+public:
+  CompactRangeWorker (
+      Database *database
+    , Nan::Callback *callback
+    , leveldb::Slice start
+    , leveldb::Slice end
+    , v8::Local<v8::Object> &startHandle
+    , v8::Local<v8::Object> &endHandle
+  );
+
+  virtual ~CompactRangeWorker ();
+  virtual void Execute ();
+  virtual void HandleOKCallback ();
+  virtual void WorkComplete ();
+
+  private:
+    leveldb::Slice start;
+    leveldb::Slice end;
+};
+
+
 } // namespace leveldown
 
 #endif

--- a/src/database_async.h
+++ b/src/database_async.h
@@ -179,8 +179,8 @@ public:
   virtual void WorkComplete ();
 
   private:
-    leveldb::Slice start;
-    leveldb::Slice end;
+    leveldb::Slice rangeStart;
+    leveldb::Slice rangeEnd;
 };
 
 

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -1,0 +1,37 @@
+const test       = require('tape')
+    , testCommon = require('abstract-leveldown/testCommon')
+    , leveldown  = require('../')
+
+var db
+
+test('setUp common', testCommon.setUp)
+
+test('setUp db', function (t) {
+  db = leveldown(testCommon.location())
+  db.open(t.end.bind(t))
+})
+
+test('test compactRange() frees disk space after key deletion', function (t) {
+  var key1 = '000000';
+  var key2 = '000001';
+  var val1 = Buffer(64).fill(1);
+  var val2 = Buffer(64).fill(1);
+  db.put(key1, val1, function() {
+    db.put(key2, val2, function() {
+      db.compactRange(key1, key2, function() {
+        db.approximateSize('0', 'z', function(err, sizeAfterPuts) {
+          db.del(key1, function() {
+            db.del(key2, function() {
+              db.compactRange(key1, key2, function() {
+                db.approximateSize('0', 'z', function(err, sizeAfterCompact) {
+                  t.notEqual(sizeAfterCompact, sizeAfterPuts);
+                  t.end();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -24,7 +24,7 @@ test('test compactRange() frees disk space after key deletion', function (t) {
             db.del(key2, function() {
               db.compactRange(key1, key2, function() {
                 db.approximateSize('0', 'z', function(err, sizeAfterCompact) {
-                  t.notEqual(sizeAfterCompact, sizeAfterPuts);
+                  t.ok(sizeAfterCompact < sizeAfterPuts);
                   t.end();
                 });
               });


### PR DESCRIPTION
This PR adds the ability to manually trigger a database compaction within a given key range for the purpose of providing better control over how and when compaction occurs.