### PR TITLE
Simplify appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,7 @@ platform:
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
   - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
-  - npm i --ignore-scripts
-  - for /f %%i in ('node -v') do set exact_nodejs_version=%%i
-  - prebuild -b %exact_nodejs_version% --strip
+  - npm i
 
 test_script:
   - npm test
-
-on_success:
-  - for %%i in (prebuilds\*) do appveyor PushArtifact %%i

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ platform:
 
 install:
   - ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: if ($env:nodejs_version -eq "5") { npm i npm@latest -g }
   - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm i
 


### PR DESCRIPTION
Use the standard build process instead of prebuild. See https://github.com/Level/leveldown/pull/381#issuecomment-325224084.

Now it doesn't have to download Node.js headers. Also won't publish an artifact (a prebuild per commit) but no one was using that anyway.