### PR TITLE
On arm the -mfloat-abi=hard flag is required

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,11 @@
         , ['OS == "linux"', {
               'cflags': [
               ]
-            , 'cflags!': [ '-fno-tree-vrp' ]
+            , 'cflags!': [ '-fno-tree-vrp']
+          }]
+        , ['target_arch == "arm"', {
+              'cflags': [ '-mfloat-abi=hard'
+              ]
           }]
         ]
       , "dependencies": [

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -142,6 +142,11 @@
                 ]
             }
         }]
+      , ['target_arch == "arm"', {
+            'cflags': [
+	        '-mfloat-abi=hard'
+	    ]
+        }]
     ]
   , 'sources': [
         'leveldb-<(ldbversion)/db/builder.cc'

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -73,6 +73,11 @@
                 ]
             }
         }]
+      , ['target_arch == "arm"', {
+            'cflags': [
+	      '-mfloat-abi=hard'
+	    ]
+        }]
     ]
   , 'sources': [
         'snappy-1.1.4/snappy-internal.h'


### PR DESCRIPTION
Leveldown will fail to build when used on ARM processors.  This change add's the appropriate flags during the build process.