### PR TITLE
add support for android cross compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,9 +20,12 @@
               ]
             , 'cflags!': [ '-fno-tree-vrp']
           }]
-        , ['target_arch == "arm"', {
-              'cflags': [ '-mfloat-abi=hard'
-              ]
+        , ['OS == "linux" and GENERATOR_FLAVOR == "android"', {
+              'cflags': [ '-std=c++0x' ]
+            , 'ldflags!': [ '-pie' , '-fPIE' ]
+          }]
+        , ['target_arch == "arm" and GENERATOR_FLAVOR != "android"', {
+              'cflags': [ '-mfloat-abi=hard' ]
           }]
         ]
       , "dependencies": [

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -74,7 +74,7 @@
               , '-Wno-unused-but-set-variable'
             ]
         }]
-      , ['OS == "linux"', {
+      , ['OS == "linux" and GENERATOR_FLAVOR != "android"', {
             'defines': [
                 'OS_LINUX=1'
             ]
@@ -83,6 +83,12 @@
             ]
           , 'ccflags': [
                 '-pthread'
+            ]
+        }]
+      , ['OS == "linux" and GENERATOR_FLAVOR == "android"', {
+            'defines': [
+                'OS_ANDROID=1'
+              , '_REENTRANT=1'
             ]
         }]
       , ['OS == "freebsd"', {
@@ -142,7 +148,7 @@
                 ]
             }
         }]
-      , ['target_arch == "arm"', {
+      , ['target_arch == "arm" and GENERATOR_FLAVOR != "android"', {
             'cflags': [
 	        '-mfloat-abi=hard'
 	    ]

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -73,7 +73,7 @@
                 ]
             }
         }]
-      , ['target_arch == "arm"', {
+      , ['target_arch == "arm" and GENERATOR_FLAVOR != "android"', {
             'cflags': [
 	      '-mfloat-abi=hard'
 	    ]


### PR DESCRIPTION
level/leveldown-mobile is using JXCore which is dead, thus I'd like to re-open #102. leveldb itself supports android cross-compilation, the trick is that gyp considers android as "flavor" of linux, thus had to write conditions based on GENERATOR_FLAVOR. Also recent change related to OpenWRT adds some complexity because in case of android on arm, hard float-abi should not be used (afaik, removed in recent versions of NDK).

With this and https://github.com/prebuild/prebuild/pull/187, cross-compilation for Android is easy as:
- make standalone toolchain (given arch and android platform version)
- export CC and CXX
- `prebuild --compile --arch <given arch> --format make-android`