### PR TITLE
add default export

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -104,4 +104,4 @@ LevelDOWN.repair = function (location, callback) {
 }
 
 
-module.exports = LevelDOWN
+module.exports = LevelDOWN.default = LevelDOWN


### PR DESCRIPTION
Enable us to use `import leveldown from 'leveldown'` by adding `default` export.