### PR TITLE
Fix Android compilation

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,6 +20,18 @@
               ]
             , 'cflags!': [ '-fno-tree-vrp']
           }]
+        , ['OS == "android"', {
+              'cflags': [ '-fPIC' ]
+            , 'ldflags': [ '-fPIC' ]
+            , 'cflags!': [
+                  '-fno-tree-vrp'
+                , '-fno-exceptions'
+                , '-mfloat-abi=hard'
+                , '-fPIE'
+              ]
+            , 'cflags_cc!': [ '-fno-exceptions' ]
+            , 'ldflags!': [ '-fPIE' ]
+          }]
         , ['target_arch == "arm"', {
               'cflags': [ '-mfloat-abi=hard'
               ]

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -4,7 +4,7 @@
         'ldbversion': '1.20'
     }
   , 'type': 'static_library'
-		# Overcomes an issue with the linker and thin .a files on SmartOS
+    # Overcomes an issue with the linker and thin .a files on SmartOS
   , 'standalone_static_library': 1
   , 'dependencies': [
         '../snappy/snappy.gyp:snappy'
@@ -142,10 +142,34 @@
                 ]
             }
         }]
+      , ['OS == "android"', {
+           'defines': [
+                'OS_ANDROID=1'
+              , '_REENTRANT=1'
+            ]
+          , 'libraries': [
+                '-lpthread'
+            ]
+          , 'ccflags': [
+                '-pthread',
+                '-fno-builtin-memcmp',
+                '-fexceptions'
+            ]
+          , 'cflags': [
+                '-fPIC'
+            ]
+          , 'cflags!': [
+                '-fno-exceptions'
+              , '-fPIE'
+              , '-mfloat-abi=hard'
+              , '-Wno-unused-but-set-variable'
+            ]
+          , 'cflags_cc!': [ '-fno-exceptions' ]
+        }]
       , ['target_arch == "arm"', {
             'cflags': [
-	        '-mfloat-abi=hard'
-	    ]
+          '-mfloat-abi=hard'
+      ]
         }]
     ]
   , 'sources': [

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -2,6 +2,7 @@
     'variables': {
         'conditions': [
             ['OS=="linux"',   {'os_include': 'linux'}]
+          , ['OS=="android"', {'os_include': 'linux'}]
           , ['OS=="mac"',     {'os_include': 'mac'}]
           , ['OS=="solaris"', {'os_include': 'solaris'}]
           , ['OS=="win"',     {'os_include': 'win32'}]
@@ -11,7 +12,7 @@
     }
   , 'target_name': 'snappy'
   , 'type': 'static_library'
-		# Overcomes an issue with the linker and thin .a files on SmartOS
+    # Overcomes an issue with the linker and thin .a files on SmartOS
   , 'standalone_static_library': 1
   , 'include_dirs': [
         '<(os_include)'
@@ -19,7 +20,7 @@
     ]
   , 'direct_dependent_settings': {
         'include_dirs': [
-        	'<(os_include)'
+          '<(os_include)'
           , 'snappy-1.1.4'
         ]
     }
@@ -73,10 +74,22 @@
                 ]
             }
         }]
+      , ['OS == "android"', {
+            'cflags': [
+                '-Wno-sign-compare'
+              , '-fPIC'
+              , '-Wno-unused-function'
+            ]
+          , 'cflags!': [
+                '-fno-tree-vrp'
+              , '-mfloat-abi=hard'
+              , '-fPIE'
+            ]
+        }]
       , ['target_arch == "arm"', {
             'cflags': [
-	      '-mfloat-abi=hard'
-	    ]
+        '-mfloat-abi=hard'
+      ]
         }]
     ]
   , 'sources': [


### PR DESCRIPTION
Using a few C flags and linker flags, mostly related to Position Independent Code (PIC). Also was important to not set `-mfloat-abi=hard` but rather let each Android architecture decide whether to use hard or soft.

I tested this on both arm and arm64 real devices. Also used it in a real use case, so these proposed changes are battle tested.