### PR TITLE
test: make sure destroy() deletes leveldb-only dir

### DIFF
--- a/test/destroy-test.js
+++ b/test/destroy-test.js
@@ -56,7 +56,7 @@ makeTest('test destroy() cleans and removes leveldb-only dir', function (db, t, 
   db.close(function (err) {
     t.notOk(err, 'no error')
     leveldown.destroy(location, function () {
-      t.notOk(fs.existsSync(), 'directory completely removed')
+      t.notOk(fs.existsSync(location), 'directory completely removed')
       done(false)
     })
   })


### PR DESCRIPTION
Discovered in a Node.js CITGM run for https://github.com/nodejs/node/pull/18308:

https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1229/nodes=fedora-latest-x64/testReport/junit/(root)/citgm/leveldown_v2_1_1/

The test is asserting that `fs.existsSync()` which is always false at the moment.