### PR TITLE
run verify-travis-appveyor as part of tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,12 @@
     "readfiletree": "~0.0.1",
     "rimraf": "^2.6.1",
     "slump": "~2.0.0",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "verify-travis-appveyor": "^2.0.0"
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "test": "(tape test/*-test.js | faucet) && prebuild-ci",
+    "test": "verify-travis-appveyor && (tape test/*-test.js | faucet) && prebuild-ci",
     "rebuild": "prebuild --compile",
     "prebuild": "prebuild --all --strip --verbose"
   },


### PR DESCRIPTION
Lets try this again.

Running this before the js tests. For some reason, if it fails on travis on osx, you don't see the output of the error and you get an additional line saying something like:

```
/Users/travis/.travis/job_stages: line 166: shell_session_update: command not found
```

This however, is unrelated to our code and related to the fact that the script exits with a non zero value.

Also, it would be nice with a yak-shaving emoji. Maybe I can get one for xmas.