### PR TITLE
Fix deprecation warnings related to Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The following options are for advanced performance tuning. Modify them only if y
 ### leveldown#put(key, value[, options], callback)
 <code>put()</code> is an instance method on an existing database object, used to store new entries, or overwrite existing entries in the LevelDB store.
 
-The `key` and `value` objects may either be strings or Buffers. Other object types are converted to strings with the `toString()` method. Keys may not be `null` or `undefined` and objects converted with `toString()` should not result in an empty-string. Values of `null`, `undefined`, `''`, `[]` and `new Buffer(0)` (and any object resulting in a `toString()` of one of these) will be stored as a zero-length character array and will therefore be retrieved as either `''` or `new Buffer(0)` depending on the type requested.
+The `key` and `value` objects may either be strings or Buffers. Other object types are converted to strings with the `toString()` method. Keys may not be `null` or `undefined` and objects converted with `toString()` should not result in an empty-string. Values of `null`, `undefined`, `''`, `[]` and `Buffer.alloc(0)` (and any object resulting in a `toString()` of one of these) will be stored as a zero-length character array and will therefore be retrieved as either `''` or `Buffer.alloc(0)` depending on the type requested.
 
 A richer set of data-types is catered for in `levelup`.
 
@@ -139,7 +139,7 @@ The `callback` function will be called with no arguments if the operation is suc
 
 The `key` object may either be a string or a Buffer and cannot be `undefined` or `null`. Other object types are converted to strings with the `toString()` method and the resulting string *may not* be a zero-length. A richer set of data-types is catered for in `levelup`.
 
-Values fetched via `get()` that are stored as zero-length character arrays (`null`, `undefined`, `''`, `[]`, `new Buffer(0)`) will return as empty-`String` (`''`) or `new Buffer(0)` when fetched with `asBuffer: true` (see below).
+Values fetched via `get()` that are stored as zero-length character arrays (`null`, `undefined`, `''`, `[]`, `Buffer.alloc(0)`) will return as empty-`String` (`''`) or `Buffer.alloc(0)` when fetched with `asBuffer: true` (see below).
 
 #### `options`
 
@@ -171,7 +171,7 @@ The `callback` function will be called with no arguments if the operation is suc
 ### leveldown#batch(operations[, options], callback)
 <code>batch()</code> is an instance method on an existing database object. Used for very fast bulk-write operations (both *put* and *delete*). The `operations` argument should be an `Array` containing a list of operations to be executed sequentially, although as a whole they are performed as an atomic operation inside LevelDB.
 
-Each operation is contained in an object having the following properties: `type`, `key`, `value`, where the *type* is either `'put'` or `'del'`. In the case of `'del'` the `'value'` property is ignored. Any entries with a `'key'` of `null` or `undefined` will cause an error to be returned on the `callback`. Any entries where the *type* is `'put'` that have a `'value'` of `undefined`, `null`, `[]`, `''` or `new Buffer(0)` will be stored as a zero-length character array and therefore be fetched during reads as either `''` or `new Buffer(0)` depending on how they are requested.
+Each operation is contained in an object having the following properties: `type`, `key`, `value`, where the *type* is either `'put'` or `'del'`. In the case of `'del'` the `'value'` property is ignored. Any entries with a `'key'` of `null` or `undefined` will cause an error to be returned on the `callback`. Any entries where the *type* is `'put'` that have a `'value'` of `undefined`, `null`, `[]`, `''` or `Buffer.alloc(0)` will be stored as a zero-length character array and therefore be fetched during reads as either `''` or `Buffer.alloc(0)` depending on how they are requested.
 
 See [`levelup`](https://github.com/level/levelup#batch) for full documentation on how this works in practice.
 

--- a/bench/memory.js
+++ b/bench/memory.js
@@ -34,7 +34,7 @@ db.open({
 
   var batch = db.batch();
   Object.keys(records).forEach(function(key) {
-    var value = new Buffer(records[key], 'hex')
+    var value = Buffer.from(records[key], 'hex')
     batch.put(key, value)
   })
 

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -14,8 +14,8 @@ test('setUp db', function (t) {
 test('test compactRange() frees disk space after key deletion', function (t) {
   var key1 = '000000';
   var key2 = '000001';
-  var val1 = Buffer(64).fill(1);
-  var val2 = Buffer(64).fill(1);
+  var val1 = Buffer.allocUnsafe(64).fill(1);
+  var val2 = Buffer.allocUnsafe(64).fill(1);
   db.put(key1, val1, function() {
     db.put(key2, val2, function() {
       db.compactRange(key1, key2, function() {

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -10,7 +10,7 @@ var async      = require('async')
   , leveldown  = require('..')
   , test       = require('tape')
 
-  , compressableData = new Buffer(Array.apply(null, Array(1024 * 100)).map(function () { return 'aaaaaaaaaa' }).join(''))
+  , compressableData = Buffer.from(Array.apply(null, Array(1024 * 100)).map(function () { return 'aaaaaaaaaa' }).join(''))
   , multiples = 10
   , dataSize = compressableData.length * multiples
 

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -50,7 +50,7 @@ make('iterator is seekable', function (db, t, done) {
 
 make('iterator is seekable with buffer', function (db, t, done) {
   var ite = db.iterator()
-  ite.seek(Buffer('two'))
+  ite.seek(Buffer.from('two'))
   ite.next(function (err, key, value) {
     t.error(err, 'no error from next()')
     t.equal(key.toString(), 'two', 'key matches')

--- a/test/leak-tester-batch.js
+++ b/test/leak-tester-batch.js
@@ -36,7 +36,7 @@ var run = CHAINED
       for (i = 0; i < 100; i++) {
         key = 'long key to test memory usage ' + String(Math.floor(Math.random() * 10000000))
         if (BUFFERS)
-          key = new Buffer(key)
+          key = Buffer.from(key)
         value = crypto.randomBytes(1024)
         if (!BUFFERS)
           value = value.toString('hex')
@@ -61,7 +61,7 @@ var run = CHAINED
       for (i = 0; i < 100; i++) {
         key = 'long key to test memory usage ' + String(Math.floor(Math.random() * 10000000))
         if (BUFFERS)
-          key = new Buffer(key)
+          key = Buffer.from(key)
         value = crypto.randomBytes(1024)
         if (!BUFFERS)
           value = value.toString('hex')

--- a/test/leak-tester.js
+++ b/test/leak-tester.js
@@ -10,7 +10,7 @@ var leveldown = require('..')
 function run () {
   var key = 'long key to test memory usage ' + String(Math.floor(Math.random() * 10000000))
 
-  if (BUFFERS) key = new Buffer(key)
+  if (BUFFERS) key = Buffer.from(key)
 
   db.get(key, function (err, value) {
     getCount++


### PR DESCRIPTION
Fixed: https://github.com/Level/leveldown/issues/451

All changes are in JS land (and the docs), no conflicts with https://github.com/Level/leveldown/pull/452.