### PR TITLE
bump prebuild-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bindings": "~1.3.0",
     "fast-future": "~1.0.2",
     "nan": "~2.10.0",
-    "prebuild-install": "^2.1.0"
+    "prebuild-install": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^8.0.31",


### PR DESCRIPTION
This will help with shorter file names for cached prebuilt binaries. Apparently there are problems with this on encrypted file systems.

Background here https://github.com/prebuild/prebuild-install/issues/77