### PR TITLE
Abstract leveldown v6 [wip]

### DIFF
--- a/leveldown.js
+++ b/leveldown.js
@@ -9,7 +9,9 @@ function LevelDOWN (location) {
     return new LevelDOWN(location)
   }
 
-  AbstractLevelDOWN.call(this, location)
+  AbstractLevelDOWN.call(this)
+
+  this.location = location
   this.binding = binding(location)
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "leveldown.js",
   "dependencies": {
-    "abstract-leveldown": "~5.0.0",
+    "abstract-leveldown": "level/abstract-leveldown#pre-remove-location",
     "bindings": "~1.3.0",
     "fast-future": "~1.0.2",
     "nan": "~2.10.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "leveldown.js",
   "dependencies": {
-    "abstract-leveldown": "level/abstract-leveldown#pre-remove-location",
+    "abstract-leveldown": "level/abstract-leveldown#remove-location",
     "bindings": "~1.3.0",
     "fast-future": "~1.0.2",
     "nan": "~2.10.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "du": "~0.1.0",
     "faucet": "0.0.1",
     "iota-array": "~1.0.0",
+    "level-concat-iterator": "^2.0.0",
     "lexicographic-integer": "~1.1.0",
     "mkfiletree": "~1.0.1",
     "monotonic-timestamp": "~0.0.8",
@@ -38,6 +39,7 @@
     "slump": "~2.0.0",
     "standard": "^11.0.1",
     "tape": "^4.5.1",
+    "tempy": "^0.2.1",
     "uuid": "^3.2.1",
     "verify-travis-appveyor": "^3.0.0"
   },

--- a/test/approximate-size-test.js
+++ b/test/approximate-size-test.js
@@ -1,5 +1,4 @@
 const test = require('tape')
-const leveldown = require('..')
 const testCommon = require('./common')
 
 var db
@@ -7,7 +6,7 @@ var db
 test('setUp common for approximate size', testCommon.setUp)
 
 test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
+  db = testCommon.factory()
   db.open(t.end.bind(t))
 })
 
@@ -67,7 +66,7 @@ test('test 1-arg + callback approximateSize() throws', function (t) {
 
 test('test custom _serialize*', function (t) {
   t.plan(4)
-  var db = leveldown(testCommon.location())
+  var db = testCommon.factory()
   db._serializeKey = function (data) { return data }
   db.approximateSize = function (start, end, callback) {
     t.deepEqual(start, { foo: 'bar' })

--- a/test/approximate-size-test.js
+++ b/test/approximate-size-test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const leveldown = require('..')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 
 var db
 

--- a/test/approximate-size-test.js
+++ b/test/approximate-size-test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const leveldown = require('..')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 
 var db
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/batch-test')
+const abstract = require('abstract-leveldown/test/batch-test')
 
 abstract.all(leveldown, test)

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/batch-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/chained-batch-test')
+const abstract = require('abstract-leveldown/test/chained-batch-test')
 
 abstract.all(leveldown, test)

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/chained-batch-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/close-test.js
+++ b/test/close-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 const abstract = require('abstract-leveldown/test/close-test')
 

--- a/test/close-test.js
+++ b/test/close-test.js
@@ -1,22 +1,9 @@
 const test = require('tape')
 const testCommon = require('./common')
-const leveldown = require('..')
 const abstract = require('abstract-leveldown/test/close-test')
 
-module.exports.setUp = function () {
-  test('setUp', testCommon.setUp)
-}
+test('setUp', testCommon.setUp)
 
-module.exports.close = abstract.close
+abstract.close(testCommon.factory, test, testCommon)
 
-module.exports.tearDown = function () {
-  test('tearDown', testCommon.tearDown)
-}
-
-module.exports.all = function (leveldown) {
-  module.exports.setUp()
-  module.exports.close(leveldown, test, testCommon)
-  module.exports.tearDown()
-}
-
-module.exports.all(leveldown)
+test('tearDown', testCommon.tearDown)

--- a/test/close-test.js
+++ b/test/close-test.js
@@ -1,7 +1,7 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/close-test')
+const abstract = require('abstract-leveldown/test/close-test')
 
 module.exports.setUp = function () {
   test('setUp', testCommon.setUp)

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,1 @@
+module.exports = require('abstract-leveldown/test/common')

--- a/test/common.js
+++ b/test/common.js
@@ -1,1 +1,9 @@
-module.exports = require('abstract-leveldown/test/common')
+const testCommon = require('abstract-leveldown/test/common')
+const tempy = require('tempy')
+const leveldown = require('..')
+
+testCommon.factory = function () {
+  return leveldown(tempy.directory())
+}
+
+module.exports = testCommon

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 
 let db

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 
 let db

--- a/test/compact-range-test.js
+++ b/test/compact-range-test.js
@@ -1,13 +1,12 @@
 const test = require('tape')
 const testCommon = require('./common')
-const leveldown = require('..')
 
 let db
 
 test('setUp common', testCommon.setUp)
 
 test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
+  db = testCommon.factory()
   db.open(t.end.bind(t))
 })
 

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -44,7 +44,7 @@ test('Compression', function (t) {
   t.test('set up', testCommon.setUp)
 
   t.test('test data is compressed by default (db.put())', function (t) {
-    var db = leveldown(testCommon.location())
+    var db = testCommon.factory()
     db.open(function (err) {
       t.error(err)
       async.forEach(
@@ -58,7 +58,7 @@ test('Compression', function (t) {
   })
 
   t.test('test data is not compressed with compression=false on open() (db.put())', function (t) {
-    var db = leveldown(testCommon.location())
+    var db = testCommon.factory()
     db.open({ compression: false }, function (err) {
       t.error(err)
       async.forEach(
@@ -72,7 +72,7 @@ test('Compression', function (t) {
   })
 
   t.test('test data is compressed by default (db.batch())', function (t) {
-    var db = leveldown(testCommon.location())
+    var db = testCommon.factory()
     db.open(function (err) {
       t.error(err)
       db.batch(

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -6,7 +6,7 @@
 const async = require('async')
 const du = require('du')
 const delayed = require('delayed')
-const common = require('abstract-leveldown/testCommon')
+const common = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 const test = require('tape')
 

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -1,12 +1,7 @@
-/* Copyright (c) 2012-2017 LevelUP contributors
- * See list at <https://github.com/level/leveldown#contributing>
- * MIT License <https://github.com/level/leveldown/blob/master/LICENSE.md>
- */
-
 const async = require('async')
 const du = require('du')
 const delayed = require('delayed')
-const common = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 const test = require('tape')
 
@@ -46,10 +41,10 @@ const cycle = function (db, compression, t, callback) {
 }
 
 test('Compression', function (t) {
-  t.test('set up', common.setUp)
+  t.test('set up', testCommon.setUp)
 
   t.test('test data is compressed by default (db.put())', function (t) {
-    var db = leveldown(common.location())
+    var db = leveldown(testCommon.location())
     db.open(function (err) {
       t.error(err)
       async.forEach(
@@ -63,7 +58,7 @@ test('Compression', function (t) {
   })
 
   t.test('test data is not compressed with compression=false on open() (db.put())', function (t) {
-    var db = leveldown(common.location())
+    var db = leveldown(testCommon.location())
     db.open({ compression: false }, function (err) {
       t.error(err)
       async.forEach(
@@ -77,7 +72,7 @@ test('Compression', function (t) {
   })
 
   t.test('test data is compressed by default (db.batch())', function (t) {
-    var db = leveldown(common.location())
+    var db = leveldown(testCommon.location())
     db.open(function (err) {
       t.error(err)
       db.batch(

--- a/test/del-test.js
+++ b/test/del-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/del-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/del-test.js
+++ b/test/del-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/del-test')
+const abstract = require('abstract-leveldown/test/del-test')
 
 abstract.all(leveldown, test)

--- a/test/destroy-test.js
+++ b/test/destroy-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const fs = require('fs')
 const path = require('path')
 const mkfiletree = require('mkfiletree')

--- a/test/destroy-test.js
+++ b/test/destroy-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('./common')
+const tempy = require('tempy')
 const fs = require('fs')
 const path = require('path')
 const mkfiletree = require('mkfiletree')
@@ -27,7 +27,7 @@ test('test callback-less, 1-arg, destroy() throws', function (t) {
 test('test destroy non-existent directory', function (t) {
   t.plan(4)
 
-  var location = testCommon.location()
+  var location = tempy.directory()
   var parent = path.dirname(location)
 
   // For symmetry with the opposite test below.
@@ -86,7 +86,8 @@ test('test destroy non leveldb directory', function (t) {
   })
 })
 
-makeTest('test destroy() cleans and removes leveldb-only dir', function (db, t, done, location) {
+makeTest('test destroy() cleans and removes leveldb-only dir', function (db, t, done) {
+  var location = db.location
   db.close(function (err) {
     t.ifError(err, 'no close error')
 
@@ -99,7 +100,8 @@ makeTest('test destroy() cleans and removes leveldb-only dir', function (db, t, 
   })
 })
 
-makeTest('test destroy() cleans and removes only leveldb parts of a dir', function (db, t, done, location) {
+makeTest('test destroy() cleans and removes only leveldb parts of a dir', function (db, t, done) {
+  var location = db.location
   fs.writeFileSync(path.join(location, 'foo'), 'FOO')
 
   db.close(function (err) {

--- a/test/destroy-test.js
+++ b/test/destroy-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const fs = require('fs')
 const path = require('path')
 const mkfiletree = require('mkfiletree')

--- a/test/get-test.js
+++ b/test/get-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/get-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/get-test.js
+++ b/test/get-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/get-test')
+const abstract = require('abstract-leveldown/test/get-test')
 
 abstract.all(leveldown, test)

--- a/test/getproperty-test.js
+++ b/test/getproperty-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 
 let db

--- a/test/getproperty-test.js
+++ b/test/getproperty-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 
 let db

--- a/test/getproperty-test.js
+++ b/test/getproperty-test.js
@@ -1,13 +1,12 @@
 const test = require('tape')
 const testCommon = require('./common')
-const leveldown = require('..')
 
 let db
 
 test('setUp common', testCommon.setUp)
 
 test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
+  db = testCommon.factory()
   db.open(t.end.bind(t))
 })
 

--- a/test/iterator-gc-test.js
+++ b/test/iterator-gc-test.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const test = require('tape')
+const collectEntries = require('level-concat-iterator')
 const testCommon = require('./common')
-const leveldown = require('..')
 const sourceData = []
 
 for (let i = 0; i < 1e3; i++) {
@@ -20,7 +20,7 @@ test('setUp', testCommon.setUp)
 test('db without ref does not get GCed while iterating', function (t) {
   t.plan(6)
 
-  let db = leveldown(testCommon.location())
+  let db = testCommon.factory()
 
   db.open(function (err) {
     t.ifError(err, 'no open error')
@@ -50,7 +50,7 @@ test('db without ref does not get GCed while iterating', function (t) {
 
   function iterate (it) {
     // No reference to db here, could be GCed. It shouldn't..
-    testCommon.collectEntries(it, function (err, entries) {
+    collectEntries(it, function (err, entries) {
       t.ifError(err, 'no iterator error')
       t.is(entries.length, sourceData.length, 'got data')
 

--- a/test/iterator-gc-test.js
+++ b/test/iterator-gc-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 const sourceData = []
 

--- a/test/iterator-gc-test.js
+++ b/test/iterator-gc-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 const sourceData = []
 

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/iterator-range-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/iterator-range-test')
+const abstract = require('abstract-leveldown/test/iterator-range-test')
 
 abstract.all(leveldown, test)

--- a/test/iterator-recursion-test.js
+++ b/test/iterator-recursion-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 const fork = require('child_process').fork
 const path = require('path')

--- a/test/iterator-recursion-test.js
+++ b/test/iterator-recursion-test.js
@@ -1,6 +1,5 @@
 const test = require('tape')
 const testCommon = require('./common')
-const leveldown = require('..')
 const fork = require('child_process').fork
 const path = require('path')
 
@@ -43,7 +42,7 @@ test('try to create an iterator with a blown stack', function (t) {
 })
 
 test('setUp db', function (t) {
-  db = leveldown(testCommon.location())
+  db = testCommon.factory()
   db.open(function (err) {
     t.error(err)
     db.batch(sourceData, t.end.bind(t))

--- a/test/iterator-recursion-test.js
+++ b/test/iterator-recursion-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 const fork = require('child_process').fork
 const path = require('path')

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -1,12 +1,12 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/iterator-test')
 const make = require('./make')
 const iota = require('iota-array')
 const lexi = require('lexicographic-integer')
 const util = require('util')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)
 
 make('iterator throws if key is not a string or buffer', function (db, t, done) {
   var keys = [null, undefined, 1, true, false]

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/iterator-test')
+const abstract = require('abstract-leveldown/test/iterator-test')
 const make = require('./make')
 const iota = require('iota-array')
 const lexi = require('lexicographic-integer')

--- a/test/leak-tester-batch.js
+++ b/test/leak-tester-batch.js
@@ -1,7 +1,7 @@
 const BUFFERS = false
 const CHAINED = false
 
-const leveldown = require('..')
+const testCommon = require('./common')
 const crypto = require('crypto')
 const assert = require('assert')
 
@@ -72,10 +72,8 @@ var run = CHAINED
     print()
   }
 
-leveldown.destroy('./leakydb', function () {
-  db = leveldown('./leakydb')
-  db.open({ xcacheSize: 0, xmaxOpenFiles: 10 }, function () {
-    rssBase = process.memoryUsage().rss
-    run()
-  })
+db = testCommon.factory()
+db.open({ xcacheSize: 0, xmaxOpenFiles: 10 }, function () {
+  rssBase = process.memoryUsage().rss
+  run()
 })

--- a/test/leak-tester.js
+++ b/test/leak-tester.js
@@ -1,6 +1,6 @@
 const BUFFERS = false
 
-const leveldown = require('..')
+const testCommon = require('./common')
 const crypto = require('crypto')
 
 let putCount = 0
@@ -40,10 +40,8 @@ function run () {
   }
 }
 
-leveldown.destroy('./leakydb', function () {
-  db = leveldown('./leakydb')
-  db.open({ xcacheSize: 0, xmaxOpenFiles: 10 }, function () {
-    rssBase = process.memoryUsage().rss
-    run()
-  })
+db = testCommon.factory()
+db.open({ xcacheSize: 0, xmaxOpenFiles: 10 }, function () {
+  rssBase = process.memoryUsage().rss
+  run()
 })

--- a/test/leveldown-test.js
+++ b/test/leveldown-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/leveldown-test')
 
-abstract.args(leveldown, test)
+abstract.args(testCommon.factory, test)

--- a/test/leveldown-test.js
+++ b/test/leveldown-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/leveldown-test')
+const abstract = require('abstract-leveldown/test/leveldown-test')
 
 abstract.args(leveldown, test)

--- a/test/make.js
+++ b/test/make.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 
 function makeTest (name, testFn) {

--- a/test/make.js
+++ b/test/make.js
@@ -1,11 +1,9 @@
 const test = require('tape')
 const testCommon = require('./common')
-const leveldown = require('..')
 
 function makeTest (name, testFn) {
   test(name, function (t) {
-    var location = testCommon.location()
-    var db = leveldown(location)
+    var db = testCommon.factory()
     var done = function (close) {
       if (close === false) {
         t.end()
@@ -24,7 +22,7 @@ function makeTest (name, testFn) {
         { type: 'put', key: 'three', value: '3' }
       ], function (err) {
         t.error(err, 'no error from batch()')
-        testFn(db, t, done, location)
+        testFn(db, t, done)
       })
     })
   })

--- a/test/make.js
+++ b/test/make.js
@@ -1,40 +1,30 @@
 const test = require('tape')
-const testCommon = require('abstract-leveldown/testCommon')
-const cleanup = testCommon.cleanup
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 
 function makeTest (name, testFn) {
   test(name, function (t) {
-    cleanup(function (err) {
-      t.error(err, 'no error after cleanup')
-      var location = testCommon.location()
-      var db = leveldown(location)
-      var done = function (close) {
-        if (close === false) {
-          cleanup(function (err) {
-            t.error(err, 'no error after cleanup')
-            t.end()
-          })
-          return
-        }
-        db.close(function (err) {
-          t.error(err, 'no error from close()')
-          cleanup(function (err) {
-            t.error(err, 'no error after cleanup')
-            t.end()
-          })
-        })
+    var location = testCommon.location()
+    var db = leveldown(location)
+    var done = function (close) {
+      if (close === false) {
+        t.end()
+        return
       }
-      db.open(function (err) {
-        t.error(err, 'no error from open()')
-        db.batch([
-          { type: 'put', key: 'one', value: '1' },
-          { type: 'put', key: 'two', value: '2' },
-          { type: 'put', key: 'three', value: '3' }
-        ], function (err) {
-          t.error(err, 'no error from batch()')
-          testFn(db, t, done, location)
-        })
+      db.close(function (err) {
+        t.error(err, 'no error from close()')
+        t.end()
+      })
+    }
+    db.open(function (err) {
+      t.error(err, 'no error from open()')
+      db.batch([
+        { type: 'put', key: 'one', value: '1' },
+        { type: 'put', key: 'two', value: '2' },
+        { type: 'put', key: 'three', value: '3' }
+      ], function (err) {
+        t.error(err, 'no error from batch()')
+        testFn(db, t, done, location)
       })
     })
   })

--- a/test/open-test.js
+++ b/test/open-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/open-test')
+const abstract = require('abstract-leveldown/test/open-test')
 
 abstract.all(leveldown, test)

--- a/test/open-test.js
+++ b/test/open-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/open-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/put-get-del-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/put-get-del-test')
+const abstract = require('abstract-leveldown/test/put-get-del-test')
 
 abstract.all(leveldown, test)

--- a/test/put-test.js
+++ b/test/put-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const leveldown = require('..')
+const testCommon = require('./common')
 const abstract = require('abstract-leveldown/test/put-test')
 
-abstract.all(leveldown, test)
+abstract.all(testCommon.factory, test)

--- a/test/put-test.js
+++ b/test/put-test.js
@@ -1,5 +1,5 @@
 const test = require('tape')
 const leveldown = require('..')
-const abstract = require('abstract-leveldown/abstract/put-test')
+const abstract = require('abstract-leveldown/test/put-test')
 
 abstract.all(leveldown, test)

--- a/test/repair-test.js
+++ b/test/repair-test.js
@@ -31,7 +31,8 @@ test('test repair non-existent directory returns error', function (t) {
 })
 
 // a proxy indicator that RepairDB is being called and doing its thing
-makeTest('test repair() compacts', function (db, t, done, location) {
+makeTest('test repair() compacts', function (db, t, done) {
+  var location = db.location
   db.close(function (err) {
     t.notOk(err, 'no error')
     var files = fs.readdirSync(location)

--- a/test/stack-blower.js
+++ b/test/stack-blower.js
@@ -6,10 +6,9 @@
   * directly, we check for a command-line argument.
   */
 const testCommon = require('./common')
-const leveldown = require('..')
 
 if (process.argv[2] === 'run') {
-  var db = leveldown(testCommon.location())
+  var db = testCommon.factory()
   var depth = 0
 
   db.open(function () {

--- a/test/stack-blower.js
+++ b/test/stack-blower.js
@@ -5,7 +5,7 @@
   * iterator-recursion-test.js. To prevent tap from trying to run this test
   * directly, we check for a command-line argument.
   */
-const testCommon = require('abstract-leveldown/test/common')
+const testCommon = require('./common')
 const leveldown = require('..')
 
 if (process.argv[2] === 'run') {

--- a/test/stack-blower.js
+++ b/test/stack-blower.js
@@ -5,26 +5,24 @@
   * iterator-recursion-test.js. To prevent tap from trying to run this test
   * directly, we check for a command-line argument.
   */
-const testCommon = require('abstract-leveldown/testCommon')
+const testCommon = require('abstract-leveldown/test/common')
 const leveldown = require('..')
 
 if (process.argv[2] === 'run') {
-  testCommon.cleanup(function () {
-    var db = leveldown(testCommon.location())
-    var depth = 0
+  var db = leveldown(testCommon.location())
+  var depth = 0
 
-    db.open(function () {
-      function recurse () {
-        db.iterator({ start: '0' })
-        depth++
-        recurse()
-      }
+  db.open(function () {
+    function recurse () {
+      db.iterator({ start: '0' })
+      depth++
+      recurse()
+    }
 
-      try {
-        recurse()
-      } catch (e) {
-        process.send('Catchable error at depth ' + depth)
-      }
-    })
+    try {
+      recurse()
+    } catch (e) {
+      process.send('Catchable error at depth ' + depth)
+    }
   })
 }


### PR DESCRIPTION
Not to be merged yet. Just to keep track of changes in `abstract-leveldown`.

However, we can obviously reuse parts of the commit log once `abstract-leveldown@v6` is released.