### PR TITLE
Use prebuildify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 
 language: node_js
 
-before_install:
-  - export JOBS=max
-
 os:
   - osx
   - linux
@@ -13,5 +10,25 @@ node_js:
   - 6
   - 8
   - 10
+  - 11
+  - node
 
-after_success: npm run coverage
+after_success:
+  - npm run coverage
+
+before_deploy:
+  - ARCHIVE_NAME="${TRAVIS_TAG:-latest}-$TRAVIS_OS_NAME-`uname -m`.tar"
+  - npm run prebuild
+  - tar --create --verbose --file="$ARCHIVE_NAME" --directory "$TRAVIS_BUILD_DIR/prebuilds" .
+
+deploy:
+  provider: releases
+  draft: false
+  prerelease: true
+  api_key:
+    secure: "FIXME!"
+  file: "$ARCHIVE_NAME"
+  skip_cleanup: true
+  on:
+    tags: true
+    node: 'node'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_deploy:
 deploy:
   provider: releases
   draft: false
-  prerelease: true
   api_key: "$PREBUILD_TOKEN"
   file: "$ARCHIVE_NAME"
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ deploy:
   provider: releases
   draft: false
   prerelease: true
-  api_key:
-    secure: "FIXME!"
+  api_key: "$PREBUILD_TOKEN"
   file: "$ARCHIVE_NAME"
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
   - 6
   - 8
   - 10
-  - 11
   - node
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ environment:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
-    - nodejs_version: "11"
     - nodejs_version: "Current"
 
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,6 @@ deploy:
     auth_token:
       secure: AjmYV2zeogfen7F6tXvR9PO1zynJVF/jhMCExQ9RMtqEHDMH8Frclym3GniZkEB0
     draft: false
-    prerelease: true
     on:
       appveyor_repo_tag: true
       nodejs_version: "Current"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ deploy:
   - provider: GitHub
     artifact: /.*\.zip/
     auth_token:
-      secure: FIXME
+      secure: AjmYV2zeogfen7F6tXvR9PO1zynJVF/jhMCExQ9RMtqEHDMH8Frclym3GniZkEB0
     draft: false
     prerelease: true
     on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,48 @@
-version: "{build}"
-build: off
-skip_tags: true
+build: false
+skip_branch_with_pr: true
 
 environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "11"
+    - nodejs_version: "Current"
 
+configuration: Release
 platform:
   - x86
   - x64
 
 install:
+  # Workaround for https://github.com/appveyor/ci/issues/2420
+  - SET PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core
+  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
   - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - git submodule update --init --recursive
   - npm i
 
 test_script:
+  - node --version
+  - npm --version
   - npm test
+
+after_test:
+  - ps: If ($env:nodejs_version -eq "Current") { npm run prebuild }
+
+artifacts:
+  - path: prebuilds
+    name: $(APPVEYOR_REPO_TAG_NAME)-win-$(PLATFORM)
+    type: zip
+
+deploy:
+  - provider: GitHub
+    artifact: /.*\.zip/
+    auth_token:
+      secure: FIXME
+    draft: false
+    prerelease: true
+    on:
+      appveyor_repo_tag: true
+      nodejs_version: "Current"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,6 @@ platform:
   - x64
 
 install:
-  # Workaround for https://github.com/appveyor/ci/issues/2420
-  - SET PATH=%PATH%;C:\Program Files\Git\mingw64\libexec\git-core
   - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
   - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "bindings": "~1.3.0",
     "fast-future": "~1.0.2",
     "napi-macros": "^1.8.1",
-    "node-gyp-build": "^3.5.1",
-    "prebuild-install": "^5.0.0"
+    "node-gyp-build": "^3.5.1"
   },
   "devDependencies": {
     "async": "^2.0.1",
@@ -28,10 +27,10 @@
     "level-concat-iterator": "^2.0.0",
     "mkfiletree": "~1.0.1",
     "monotonic-timestamp": "~0.0.8",
+    "node-gyp": "^3.8.0",
     "nyc": "^12.0.2",
     "optimist": "~0.6.1",
-    "prebuild": "^8.0.0",
-    "prebuild-ci": "^2.0.0",
+    "prebuildify": "^2.9.1",
     "readfiletree": "~0.0.1",
     "remark-cli": "^5.0.0",
     "remark-github": "^7.0.3",
@@ -40,15 +39,14 @@
     "standard": "^12.0.0",
     "tape": "^4.5.1",
     "tempy": "^0.2.1",
-    "uuid": "^3.2.1",
-    "verify-travis-appveyor": "^3.0.0"
+    "uuid": "^3.2.1"
   },
   "scripts": {
     "install": "node-gyp-build",
-    "test": "standard && verify-travis-appveyor && nyc tape test/*-test.js && prebuild-ci",
+    "test": "standard && nyc tape test/*-test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "rebuild": "prebuild --compile",
-    "prebuild": "prebuild --all --strip --verbose",
+    "rebuild": "node-gyp rebuild --verbose",
+    "prebuild": "prebuildify --napi --strip",
     "changelog": "remark CHANGELOG.md -o"
   },
   "remarkConfig": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "install": "node-gyp-build",
     "test": "standard && nyc tape test/*-test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "rebuild": "node-gyp rebuild --verbose",
+    "rebuild": "node-gyp rebuild",
     "prebuild": "prebuildify --napi --strip",
     "changelog": "remark CHANGELOG.md -o"
   },


### PR DESCRIPTION
Closes https://github.com/Level/leveldown/issues/482 , closes https://github.com/Level/leveldown/issues/536

TODO

- [x] Add secure key for Travis
- [x] Add secure key for AppVeyor

@vweevers I'm not 100% sure about the changes to `appveyor.yml`. I've taken the setup from `prebuildify-ci` and `sodium-native` (which now uses travis for windows)

* https://github.com/mafintosh/prebuildify-ci/blob/master/index.js#L145-L187
* https://github.com/sodium-friends/sodium-native/blob/e203fd5306583ba4d719ca679c8f97333615ffbb/appveyor.yml