### PR TITLE
Update minimum node version required

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   "license": "MIT",
   "gypfile": true,
   "engines": {
-    "node": ">=6"
+    "node": ">=8.6.0"
   }
 }


### PR DESCRIPTION
Closes https://github.com/Level/leveldown/issues/551

I started with `v8.0.0` and moved upwards. The problem is related to `napi_throw_error()` which was added in `v8.0.0` but the function signature has changed from two parameters to three.

https://nodejs.org/dist/latest-v10.x/docs/api/n-api.html#n_api_napi_throw_error

Update:

There are more issues, not just related to `napi_throw_error()`.