### PR TITLE
Remove legacy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "abstract-leveldown": "~6.0.0",
-    "bindings": "~1.3.0",
     "fast-future": "~1.0.2",
     "napi-macros": "~1.8.1",
     "node-gyp-build": "~3.7.0"


### PR DESCRIPTION
Remove the [bindings](https://github.com/TooTallNate/node-bindings) module from dependencies since we are now using [node-gyp-build](https://github.com/mafintosh/node-gyp-build) to load NAPI bindings.