### PR TITLE
End iterator on GC or db close

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -53,9 +53,4 @@ Iterator.prototype._next = function (callback) {
   return this
 }
 
-Iterator.prototype._end = function (callback) {
-  delete this.cache
-  binding.iterator_end(this.context, callback)
-}
-
 module.exports = Iterator

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "leveldown.js",
   "scripts": {
     "install": "node-gyp-build",
-    "test": "standard && nyc tape test/*-test.js",
+    "test": "standard && npm run test-gc && nyc tape test/*-test.js",
     "test-gc": "npx -n=--expose-gc tape test/{cleanup,iterator-gc,chained-batch-gc}*-test.js",
     "test-electron": "electron test/electron.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/test/cleanup-hanging-iterators-test.js
+++ b/test/cleanup-hanging-iterators-test.js
@@ -1,8 +1,8 @@
 const makeTest = require('./make')
 const repeats = 200
 
-makeTest('test ended iterator', function (db, t, done) {
-  // First test normal and proper usage: calling it.end() before db.close()
+makeTest('test legacy ended iterator', function (db, t, done) {
+  // First test the old proper usage: calling it.end() before db.close().
   var it = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
 
   it.next(function (err, key, value) {
@@ -17,7 +17,7 @@ makeTest('test ended iterator', function (db, t, done) {
 })
 
 makeTest('test likely-ended iterator', function (db, t, done) {
-  // Test improper usage: not calling it.end() before db.close(). Cleanup of the
+  // Test simpler usage: not calling it.end() before db.close(). Cleanup of the
   // database will crash Node if not handled properly.
   var it = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
 
@@ -49,7 +49,7 @@ makeTest('test non-ended iterator', function (db, t, done) {
 
 makeTest('test multiple likely-ended iterators', function (db, t, done) {
   // Same as the test above but repeated and with an extra iterator that is not
-  // nexting, which means its EndWorker will be executed almost immediately.
+  // nexting, which follows a different (faster) code path.
   for (let i = 0; i < repeats; i++) {
     db.iterator()
     db.iterator().next(function () {})
@@ -70,7 +70,7 @@ makeTest('test multiple non-ended iterators', function (db, t, done) {
 
 global.gc && makeTest('test multiple non-ended iterators with forced gc', function (db, t, done) {
   // Same as the test above but with forced GC, to test that the lifespan of an
-  // iterator is tied to *both* its JS object and whether the iterator was ended.
+  // iterator is tied to *both* its JS object and whether it's busy (nexting).
   for (let i = 0; i < repeats; i++) {
     db.iterator({ highWaterMark: 0 })
     db.iterator({ highWaterMark: 0 }).next(function () {})
@@ -83,6 +83,7 @@ global.gc && makeTest('test multiple non-ended iterators with forced gc', functi
 })
 
 global.gc && makeTest('test multiple iterators with forced gc in next()', function (db, t, done) {
+  // Simulate GC in between NextWorker::DoComplete() and ::DoFinally().
   for (let i = 0; i < 10; i++) {
     db.iterator({ highWaterMark: 0 }).next(function () {
       global.gc()
@@ -92,8 +93,8 @@ global.gc && makeTest('test multiple iterators with forced gc in next()', functi
   setImmediate(done)
 })
 
-makeTest('test ending iterators', function (db, t, done) {
-  // At least one end() should be in progress when we try to close the db.
+makeTest('test legacy ended iterators', function (db, t, done) {
+  // This test doesn't have added value anymore.
   var it1 = db.iterator().next(function () {
     it1.end(function () {})
   })

--- a/test/cleanup-hanging-iterators-test.js
+++ b/test/cleanup-hanging-iterators-test.js
@@ -82,6 +82,16 @@ global.gc && makeTest('test multiple non-ended iterators with forced gc', functi
   }, Math.floor(Math.random() * 50))
 })
 
+global.gc && makeTest('test multiple iterators with forced gc in next()', function (db, t, done) {
+  for (let i = 0; i < 10; i++) {
+    db.iterator({ highWaterMark: 0 }).next(function () {
+      global.gc()
+    })
+  }
+
+  setImmediate(done)
+})
+
 makeTest('test ending iterators', function (db, t, done) {
   // At least one end() should be in progress when we try to close the db.
   var it1 = db.iterator().next(function () {

--- a/test/make.js
+++ b/test/make.js
@@ -1,7 +1,16 @@
 const test = require('tape')
 const testCommon = require('./common')
 
-function makeTest (name, testFn) {
+function makeTest (name, testFn, repeat) {
+  // Temporary
+  if (repeat !== false) {
+    for (let i = 0; i < 50; i++) {
+      makeTest(`${name} (${i})`, testFn, false)
+    }
+
+    return
+  }
+
   test(name, function (t) {
     var db = testCommon.factory()
     var done = function (err, close) {


### PR DESCRIPTION
Removing the need for the user to do `iterator.end()`, following the suggestion by @chjj in https://github.com/Level/leveldown/pull/597#issuecomment-472756492.

For early review; needs a CI run, some light refactoring and comments to clarify the order of things.