### PR TITLE
Temporarily skip hallmark test because it breaks citgm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "leveldown.js",
   "scripts": {
     "install": "node-gyp-build",
-    "test": "standard && hallmark && nyc tape test/*-test.js",
+    "test": "standard && nyc tape test/*-test.js",
     "test-gc": "npx -n=--expose-gc tape test/{cleanup,iterator-gc}*-test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "rebuild": "node-gyp rebuild",


### PR DESCRIPTION
Fixes one half of https://github.com/nodejs/citgm/issues/694.

The problem is that CITGM doesn't clone the repo, so hallmark (more specifically, [remark-git-contributors](https://github.com/remarkjs/remark-git-contributors)) throws. Later on this should fixed in hallmark.

See also https://github.com/Level/level/pull/145