### PR TITLE
Remove electron prebuilds in favor of runtime-agnostic prebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-electron": "electron test/electron.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "rebuild": "node-gyp rebuild",
-    "prebuild": "prebuildify -t 8.14.0 -t electron@3.0.0 --napi --strip",
+    "prebuild": "prebuildify -t 8.14.0 --napi --strip",
     "download-prebuilds": "prebuildify-ci download",
     "hallmark": "hallmark --fix",
     "dependency-check": "dependency-check . test/*.js bench/*.js",


### PR DESCRIPTION
Closes #602. This will make Electron use the `node-napi.node` prebuilds. That breaks Electron 3 on Windows, but fixes Electron 4 on Windows (see #602). I prefer supporting latest. WDYT?

(Linux and Mac are not affected by this AFAIK)