### PR TITLE
Throw error in iterator_seek if iterator has ended

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1367,6 +1367,10 @@ NAPI_METHOD(iterator_seek) {
   NAPI_ARGV(2);
   NAPI_ITERATOR_CONTEXT();
 
+  if (iterator->ended_) {
+    napi_throw_error(env, NULL, "iterator has ended");
+  }
+
   iterator->ReleaseTarget();
   iterator->target_ = new leveldb::Slice(ToSlice(env, argv[1]));
   iterator->GetIterator();


### PR DESCRIPTION
Cherry picked from #601.

We do the same check in JS-land (in `abstract-leveldown`), so this is purely for safety.