### PR TITLE
Skip writing empty (chained) batch and make callbacks asynchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile"
   },
   "dependencies": {
-    "abstract-leveldown": "~6.0.0",
+    "abstract-leveldown": "~6.0.3",
     "fast-future": "~1.0.2",
     "napi-macros": "~1.8.1",
     "node-gyp-build": "~3.8.0"


### PR DESCRIPTION
While hunting for bugs (see thread in #601) I found that:

1. The `hasData_` property of chained batch is unused. Though LevelDB seems to be fine with writing an empty batch, this PR skips that if `hasData_` is false, so that the behavior is symmetric with `batch([])` (array-form) and with `leveldown@4x`.
2. The callback of `batch([])` (array-form) isn't asynchronous if the array is empty.