### PR TITLE
Update prebuildify and node-gyp-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - name: arm
       os: linux
       node_js: node
-      env: [BUILD_CMD=prebuild-arm, BUILD_GROUP=arm]
+      env: [BUILD_CMD=prebuild-arm, BUILD_GROUP=arm, NPM_CONFIG_IGNORE_SCRIPTS=1]
       if: tag is present
 
 script:
@@ -42,7 +42,7 @@ after_success:
 
 before_deploy:
   - export ARCHIVE_NAME="${TRAVIS_TAG:-latest}-$BUILD_GROUP.tar.gz"
-  - npm run $BUILD_CMD
+  - NPM_CONFIG_IGNORE_SCRIPTS= npm run $BUILD_CMD
   - file prebuilds/*/*
   - tar -zcvf "$ARCHIVE_NAME" -C prebuilds .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ jobs:
       node_js: node
       env: [BUILD_CMD=prebuild-arm, BUILD_GROUP=arm, NPM_CONFIG_IGNORE_SCRIPTS=1]
       if: tag is present
+    - name: alpine
+      os: linux
+      node_js: node
+      env: [BUILD_CMD=prebuild-alpine, BUILD_GROUP=alpine, NPM_CONFIG_IGNORE_SCRIPTS=1]
+      if: tag is present
 
 script:
   - if [[ ! -z "$TEST" ]]; then npm run test; fi

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ $ git submodule update --init --recursive
 2. Push to GitHub: `git push --follow-tags`
 3. Wait for Travis and AppVeyor builds to complete
 4. Download prebuilds into `./prebuilds`: `npm run download-prebuilds`
-5. Optionally verify loading a prebuild: `rimraf build && npm t`
+5. Optionally verify loading a prebuild: `npm run test-prebuild`
 6. Optionally verify which files npm will include: `irish-pub`
 7. Add changelog to the GitHub release
 8. Finally: `npm publish`

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-gyp": "^4.0.0",
     "nyc": "^14.0.0",
     "optimist": "~0.6.1",
-    "prebuildify": "prebuild/prebuildify#override-platform",
+    "prebuildify": "^3.0.0",
     "prebuildify-ci": "^1.0.4",
     "readfiletree": "~0.0.1",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prebuild-linux-armv7": "IMAGE=linux-armv7 ./scripts/cross-compile --tag-armv",
     "prebuild-linux-arm64": "IMAGE=linux-arm64 ./scripts/cross-compile --tag-armv",
     "prebuild-android-armv7": "IMAGE=android-armv7 ./scripts/cross-compile --tag-armv",
-    "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile --tag-armv"
+    "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile --tag-armv",
+    "prebuild-alpine": "IMAGE=alpine ./scripts/cross-compile --tag-libc"
   },
   "dependencies": {
     "abstract-leveldown": "~6.0.3",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "dependency-check": "dependency-check . test/*.js bench/*.js",
     "prepublishOnly": "npm run dependency-check",
     "prebuild-arm": "npm run prebuild-linux-armv7 && npm run prebuild-linux-arm64 && npm run prebuild-android-armv7 && npm run prebuild-android-arm64",
-    "prebuild-linux-armv7": "IMAGE=linux-armv7 ./scripts/cross-compile",
-    "prebuild-linux-arm64": "IMAGE=linux-arm64 ./scripts/cross-compile",
-    "prebuild-android-armv7": "IMAGE=android-armv7 ./scripts/cross-compile",
-    "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile"
+    "prebuild-linux-armv7": "IMAGE=linux-armv7 ./scripts/cross-compile --tag-armv",
+    "prebuild-linux-arm64": "IMAGE=linux-arm64 ./scripts/cross-compile --tag-armv",
+    "prebuild-android-armv7": "IMAGE=android-armv7 ./scripts/cross-compile --tag-armv",
+    "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile --tag-armv"
   },
   "dependencies": {
     "abstract-leveldown": "~6.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "abstract-leveldown": "~6.0.3",
     "fast-future": "~1.0.2",
     "napi-macros": "~1.8.1",
-    "node-gyp-build": "~3.8.0"
+    "node-gyp-build": "~4.1.0"
   },
   "devDependencies": {
     "async": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "standard && nyc tape test/*-test.js",
     "test-gc": "npx -n=--expose-gc tape test/{cleanup,iterator-gc,chained-batch-gc}*-test.js",
     "test-electron": "electron test/electron.js",
+    "test-prebuild": "cross-env PREBUILDS_ONLY=1 npm t",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "rebuild": "node-gyp rebuild",
     "prebuild": "prebuildify -t 8.14.0 --napi --strip",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "async": "^2.0.1",
     "coveralls": "^3.0.2",
+    "cross-env": "^5.2.0",
     "delayed": "^1.0.1",
     "dependency-check": "^3.3.0",
     "du": "~0.1.0",

--- a/scripts/cross-compile
+++ b/scripts/cross-compile
@@ -4,4 +4,4 @@ DOCKER_USER="node"
 if [[ "$TRAVIS" == "true" ]]; then DOCKER_USER="travis"; fi
 
 exec docker run -u ${DOCKER_USER} --rm -v $(pwd):/app prebuild/${IMAGE} \
-     bash -c "npm i --ignore-scripts && npx prebuildify -t 8.14.0 --napi --strip"
+     npm run prebuild -- $@


### PR DESCRIPTION
Tackles the final items of #575. Alpine and iOS are yet to do but we have a separate issues for those (#388 and #626). Supersedes #622.

Semver-minor because of the added `armv` tag.

Once https://github.com/prebuild/docker-images/pull/5 lands and is built+pushed, I'll temporarily modify our `.travis.yml` here to enable the `arm` job without uploading prebuilds. IMO we don't have to smoke-test a release again.