### PR TITLE
Remove fast-future

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -689,6 +689,8 @@ struct Iterator {
 
   bool IteratorNext (std::vector<std::pair<std::string, std::string> >& result) {
     size_t size = 0;
+    uint32_t cacheSize = 0;
+
     while (true) {
       std::string key, value;
       bool ok = Read(key, value);
@@ -704,6 +706,9 @@ struct Iterator {
         size = size + key.size() + value.size();
         if (size > highWaterMark_) return true;
 
+        // Limit the size of the cache to prevent starving the event loop
+        // in JS-land while we're recursively calling process.nextTick().
+        if (++cacheSize >= 1000) return true;
       } else {
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "abstract-leveldown": "~6.0.3",
-    "fast-future": "~1.0.2",
     "napi-macros": "~1.8.1",
     "node-gyp-build": "~4.1.0"
   },

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -35,7 +35,7 @@ test('iterator does not starve event loop', function (t) {
       let entries = 0
       let scheduled = false
 
-      // Iterate continously while also scheduling work with setImmediate(),
+      // Iterate continuously while also scheduling work with setImmediate(),
       // which should be given a chance to run because we limit the tick depth.
       const next = function () {
         it.next(function (err, key, value) {

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -42,10 +42,7 @@ test('iterator does not starve event loop', function (t) {
           if (err || (key === undefined && value === undefined)) {
             t.ifError(err, 'no next error')
             t.is(entries, sourceData.length, 'got all data')
-            t.ok(breaths > 1, 'breathed while iterating: ' + breaths)
-
-            // More precise assertion (only works for cache size limit, not fast-future):
-            // t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
+            t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
 
             return db.close(function (err) {
               t.ifError(err, 'no close error')

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const test = require('tape')
+const testCommon = require('./common')
+const sourceData = []
+
+// For this test the number of records in the db must be a multiple of
+// the hardcoded fast-future limit (1000) or a cache size limit in C++.
+for (let i = 0; i < 1e4; i++) {
+  sourceData.push({
+    type: 'put',
+    key: i.toString(),
+    value: ''
+  })
+}
+
+test('setUp', testCommon.setUp)
+
+test('iterator does not starve event loop', function (t) {
+  t.plan(6)
+
+  const db = testCommon.factory()
+
+  db.open(function (err) {
+    t.ifError(err, 'no open error')
+
+    // Insert test data
+    db.batch(sourceData.slice(), function (err) {
+      t.ifError(err, 'no batch error')
+
+      // Set a high highWaterMark to fill up the cache entirely
+      const it = db.iterator({ highWaterMark: Math.pow(1024, 3) })
+
+      let breaths = 0
+      let entries = 0
+      let scheduled = false
+
+      // Iterate continously while also scheduling work with setImmediate(),
+      // which should be given a chance to run because we limit the tick depth.
+      const next = function () {
+        it.next(function (err, key, value) {
+          if (err || (key === undefined && value === undefined)) {
+            t.ifError(err, 'no next error')
+            t.is(entries, sourceData.length, 'got all data')
+            t.ok(breaths > 1, 'breathed while iterating: ' + breaths)
+
+            // More precise assertion (only works for cache size limit, not fast-future):
+            // t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
+
+            return db.close(function (err) {
+              t.ifError(err, 'no close error')
+            })
+          }
+
+          entries++
+
+          if (!scheduled) {
+            scheduled = true
+            setImmediate(function () {
+              breaths++
+              scheduled = false
+            })
+          }
+
+          next()
+        })
+      }
+
+      next()
+    })
+  })
+})
+
+test('tearDown', testCommon.tearDown)


### PR DESCRIPTION
We can remove `fast-future`, because the iterator's cache mechanism already prevents event loop starvation (as mentioned by @peakji in https://github.com/Level/leveldown/issues/327#issuecomment-267666833) - unless you have single-byte keys and values. To handle that rare case we can move the internal counter of `fast-future` to the C++ of `leveldown`: it eithers stop iterating when it hits the `highWaterMark` (in bytes) or when the cache is [1000](https://github.com/kesla/fast-future/blob/0a08e26e4c822a342b200b0fd9c2608cff3fefa7/fast-future.js#L1) elements long.