### PR TITLE
Immutable cache array

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1537,9 +1537,8 @@ struct NextWorker final : public BaseWorker {
         napi_create_string_utf8(env_, value.data(), value.size(), &returnValue);
       }
 
-      // put the key & value in a descending order, so that they can be .pop:ed in javascript-land
-      napi_set_element(env_, jsArray, static_cast<int>(arraySize - idx * 2 - 1), returnKey);
-      napi_set_element(env_, jsArray, static_cast<int>(arraySize - idx * 2 - 2), returnValue);
+      napi_set_element(env_, jsArray, static_cast<int>(idx * 2), returnKey);
+      napi_set_element(env_, jsArray, static_cast<int>(idx * 2 + 1), returnValue);
     }
 
     // clean up & handle the next/end state

--- a/binding.cc
+++ b/binding.cc
@@ -689,6 +689,8 @@ struct Iterator {
 
   bool IteratorNext (std::vector<std::pair<std::string, std::string> >& result) {
     size_t size = 0;
+    uint32_t cacheSize = 0;
+
     while (true) {
       std::string key, value;
       bool ok = Read(key, value);
@@ -704,6 +706,9 @@ struct Iterator {
         size = size + key.size() + value.size();
         if (size > highWaterMark_) return true;
 
+        // Limit the size of the cache to prevent starving the event loop
+        // in JS-land while we're recursively calling process.nextTick().
+        if (++cacheSize >= 1000) return true;
       } else {
         return false;
       }

--- a/iterator.js
+++ b/iterator.js
@@ -6,6 +6,7 @@ function Iterator (db, options) {
   AbstractIterator.call(this, db)
 
   this.context = binding.iterator_init(db.context, options)
+  this.offset = 0
   this.cache = null
   this.finished = false
 }
@@ -17,6 +18,7 @@ Iterator.prototype._seek = function (target) {
     throw new Error('cannot seek() to an empty target')
   }
 
+  this.offset = 0
   this.cache = null
   binding.iterator_seek(this.context, target)
   this.finished = false
@@ -25,14 +27,15 @@ Iterator.prototype._seek = function (target) {
 Iterator.prototype._next = function (callback) {
   var that = this
 
-  if (this.cache && this.cache.length) {
-    process.nextTick(callback, null, this.cache.pop(), this.cache.pop())
+  if (this.cache && this.offset + 2 <= this.cache.length) {
+    process.nextTick(callback, null, this.cache[this.offset++], this.cache[this.offset++])
   } else if (this.finished) {
     process.nextTick(callback)
   } else {
     binding.iterator_next(this.context, function (err, array, finished) {
       if (err) return callback(err)
 
+      that.offset = 0
       that.cache = array
       that.finished = finished
       that._next(callback)
@@ -43,7 +46,6 @@ Iterator.prototype._next = function (callback) {
 }
 
 Iterator.prototype._end = function (callback) {
-  delete this.cache
   binding.iterator_end(this.context, callback)
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "abstract-leveldown": "~6.0.3",
-    "fast-future": "~1.0.2",
     "napi-macros": "~1.8.1",
     "node-gyp-build": "~4.1.0"
   },

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -35,7 +35,7 @@ test('iterator does not starve event loop', function (t) {
       let entries = 0
       let scheduled = false
 
-      // Iterate continously while also scheduling work with setImmediate(),
+      // Iterate continuously while also scheduling work with setImmediate(),
       // which should be given a chance to run because we limit the tick depth.
       const next = function () {
         it.next(function (err, key, value) {

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -42,10 +42,7 @@ test('iterator does not starve event loop', function (t) {
           if (err || (key === undefined && value === undefined)) {
             t.ifError(err, 'no next error')
             t.is(entries, sourceData.length, 'got all data')
-            t.ok(breaths > 1, 'breathed while iterating: ' + breaths)
-
-            // More precise assertion (only works for cache size limit, not fast-future):
-            // t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
+            t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
 
             return db.close(function (err) {
               t.ifError(err, 'no close error')

--- a/test/iterator-starvation-test.js
+++ b/test/iterator-starvation-test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const test = require('tape')
+const testCommon = require('./common')
+const sourceData = []
+
+// For this test the number of records in the db must be a multiple of
+// the hardcoded fast-future limit (1000) or a cache size limit in C++.
+for (let i = 0; i < 1e4; i++) {
+  sourceData.push({
+    type: 'put',
+    key: i.toString(),
+    value: ''
+  })
+}
+
+test('setUp', testCommon.setUp)
+
+test('iterator does not starve event loop', function (t) {
+  t.plan(6)
+
+  const db = testCommon.factory()
+
+  db.open(function (err) {
+    t.ifError(err, 'no open error')
+
+    // Insert test data
+    db.batch(sourceData.slice(), function (err) {
+      t.ifError(err, 'no batch error')
+
+      // Set a high highWaterMark to fill up the cache entirely
+      const it = db.iterator({ highWaterMark: Math.pow(1024, 3) })
+
+      let breaths = 0
+      let entries = 0
+      let scheduled = false
+
+      // Iterate continously while also scheduling work with setImmediate(),
+      // which should be given a chance to run because we limit the tick depth.
+      const next = function () {
+        it.next(function (err, key, value) {
+          if (err || (key === undefined && value === undefined)) {
+            t.ifError(err, 'no next error')
+            t.is(entries, sourceData.length, 'got all data')
+            t.ok(breaths > 1, 'breathed while iterating: ' + breaths)
+
+            // More precise assertion (only works for cache size limit, not fast-future):
+            // t.is(breaths, sourceData.length / 1000, 'breathed while iterating')
+
+            return db.close(function (err) {
+              t.ifError(err, 'no close error')
+            })
+          }
+
+          entries++
+
+          if (!scheduled) {
+            scheduled = true
+            setImmediate(function () {
+              breaths++
+              scheduled = false
+            })
+          }
+
+          next()
+        })
+      }
+
+      next()
+    })
+  })
+})
+
+test('tearDown', testCommon.tearDown)


### PR DESCRIPTION
Implemented two minor changes that might give us a performance gain:

* No need to reverse the array in C++ land, this will avoid creating slow arrays with holes.
* Remove `.pop()` operations in JS land, leave the `cache` array immutable.

I haven't run the benchmarks yet, @vweevers is there any benchmark script suitable for this one?

Note: I forked this brach from [remove-fast-future](https://github.com/Level/leveldown/tree/remove-fast-future), I'll rebase after https://github.com/Level/leveldown/pull/638 gets merged.