### PR TITLE
Replace Ubuntu 16.04 with CentOS 7 for prebuilds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       env: [TEST=1]
     - os: linux
       node_js: node
-      env: [TEST=1, TEST_ELECTRON=1, BUILD_CMD=prebuild, BUILD_GROUP=linux-x64]
+      env: [TEST=1, TEST_ELECTRON=1]
       addons:
         apt:
           packages:
@@ -27,6 +27,11 @@ jobs:
     - os: osx
       node_js: node
       env: [TEST=1, TEST_ELECTRON=1, BUILD_CMD=prebuild, BUILD_GROUP=darwin-x64]
+    - name: centos7
+      os: linux
+      node_js: node
+      env: [BUILD_CMD=prebuild-centos7, BUILD_GROUP=linux-x64, NPM_CONFIG_IGNORE_SCRIPTS=1]
+      if: tag is present
     - name: arm
       os: linux
       node_js: node

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "prebuild-linux-arm64": "IMAGE=linux-arm64 ./scripts/cross-compile --tag-armv",
     "prebuild-android-armv7": "IMAGE=android-armv7 ./scripts/cross-compile --tag-armv",
     "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile --tag-armv",
-    "prebuild-alpine": "IMAGE=alpine ./scripts/cross-compile --tag-libc"
+    "prebuild-alpine": "IMAGE=alpine ./scripts/cross-compile --tag-libc",
+    "prebuild-centos7": "IMAGE=centos7-devtoolset7 ./scripts/cross-compile"
   },
   "dependencies": {
     "abstract-leveldown": "~6.1.1",


### PR DESCRIPTION
* Remove prebuild settings from standard "linux" job
* Add centos7 job with prebuild settings
* Add centos7-devtoolset7 docker image prebuild script

Ref: https://github.com/prebuild/docker-images/pull/8
Ref: https://github.com/Level/leveldown/pull/672

For your consideration, no pressure on this if it's reaching too far, I won't be upset if you don't like it!