### PR TITLE
Produce a unique namespace at compile time

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -13,6 +13,16 @@
 #include <vector>
 
 /**
+ * Produce a unique namespace at compile time so that symbols don't
+ * clash when multiple versions of the addon are loaded into node.
+ */
+#define CONCAT_(a,b) a##b
+#define CONCAT(a,b) CONCAT_(a,b)
+#define NS CONCAT(NODE_GYP_MODULE_NAME,MODULE_SEED)
+
+namespace NS {
+
+/**
  * Forward declarations.
  */
 struct Database;
@@ -1764,4 +1774,6 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(batch_del);
   NAPI_EXPORT_FUNCTION(batch_clear);
   NAPI_EXPORT_FUNCTION(batch_write);
+}
+
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,9 @@
 {
   "targets": [{
     "target_name": "leveldown",
+    "defines": [
+      "MODULE_SEED=<!(node -p \"crypto.randomBytes(16).toString('hex')\")"
+    ],
     "conditions": [
       ["OS == 'win'", {
         "defines": [


### PR DESCRIPTION
So that symbols don't clash when multiple versions of the addon are loaded into node.

Closes #686. Summary of that thread: when two 5.x versions of `leveldown` are loaded side by side, for example 5.3.0 and 5.0.2, their (static) methods conflict. E.g. if you open a 5.0.2 db, on completion Node.js will call the `BaseWorker::Complete` method of 5.3.0.

Some remaining questions:

- Could this be considered a bug in node?
- Is there a better solution?
- Only makes leveldown symbols unique, not leveldb symbols
- ~~I've only tested debug builds so far~~