### PR TITLE
Hide symbols for mac with -fvisibility=hidden

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,12 @@
         "cflags": [],
         "cflags!": [ "-fno-tree-vrp"]
       }],
+      ["OS == 'mac'", {
+        "cflags+": ["-fvisibility=hidden"],
+        "xcode_settings": {
+          "GCC_SYMBOLS_PRIVATE_EXTERN": "YES" # -fvisibility=hidden
+        }
+      }],
       ["OS == 'android'", {
         "cflags": [ "-fPIC" ],
         "ldflags": [ "-fPIC" ],


### PR DESCRIPTION
Closes #686. Alternative to #687 - see https://github.com/Level/leveldown/pull/687#issuecomment-544142900. I'm hoping for some feedback on https://github.com/nodejs/node-addon-api/pull/460#issuecomment-544143695.

I tested this and it works, but I don't fully understand why yet. Here's the difference between the symbol tables of a `leveldown` master build (as `node_modules/ldmaster`) and this PR (as `node_modules/ldhidden`):

<details>
<summary>Click to expand</summary>

```
$ objdump --syms node_modules/ldmaster/build/Release/leveldown.node | grep -i baseworker
0000000000000000 l    d  *UND*	__ZTV10BaseWorker
0000000000004732 lw    F __TEXT,__text	__ZN10BaseWorkerC2EP10napi_env__P8DatabaseP12napi_value__PKc
0000000000004898 lw    F __TEXT,__text	__ZN10BaseWorker9DoFinallyEv
000000000000489e lw    F __TEXT,__text	__ZN10BaseWorker16HandleOKCallbackEv
0000000000004956 lw    F __TEXT,__text	__ZN10BaseWorkerD1Ev
0000000000004956 l     F __TEXT,__text	__ZN10BaseWorkerD0Ev
000000000000495c lw    F __TEXT,__text	__ZN10BaseWorker10DoCompleteEv
0000000000004a2a lw    F __TEXT,__text	__ZN10BaseWorkerD2Ev
0000000000004a80 lw    F __TEXT,__text	__ZN10BaseWorker9SetStatusEN7leveldb6StatusE
0000000000004b66 lw    F __TEXT,__text	__ZN10BaseWorker15SetErrorMessageEPKc
0000000000004912 gw    F __TEXT,__text	__ZN10BaseWorker7ExecuteEP10napi_env__Pv
0000000000004920 gw    F __TEXT,__text	__ZN10BaseWorker8CompleteEP10napi_env__11napi_statusPv
000000000002e4a0 lw    O __DATA,__const	__ZTV10BaseWorker

$ objdump --syms node_modules/ldhidden/build/Release/leveldown.node | grep -i baseworker
0000000000000000 l    d  *UND*	__ZTV10BaseWorker
000000000000468a lw    F __TEXT,__text	__ZN10BaseWorkerC2EP10napi_env__P8DatabaseP12napi_value__PKc
00000000000047ec lw    F __TEXT,__text	__ZN10BaseWorker9DoFinallyEv
00000000000047f2 lw    F __TEXT,__text	__ZN10BaseWorker16HandleOKCallbackEv
00000000000048aa lw    F __TEXT,__text	__ZN10BaseWorkerD1Ev
00000000000048b0 lw    F __TEXT,__text	__ZN10BaseWorkerD0Ev
00000000000048b6 lw    F __TEXT,__text	__ZN10BaseWorker10DoCompleteEv
0000000000004980 lw    F __TEXT,__text	__ZN10BaseWorkerD2Ev
00000000000049d2 lw    F __TEXT,__text	__ZN10BaseWorker9SetStatusEN7leveldb6StatusE
0000000000004ab8 lw    F __TEXT,__text	__ZN10BaseWorker15SetErrorMessageEPKc
0000000000004866 lw    F __TEXT,__text	__ZN10BaseWorker7ExecuteEP10napi_env__Pv
0000000000004874 lw    F __TEXT,__text	__ZN10BaseWorker8CompleteEP10napi_env__11napi_statusPv
000000000002e418 lw    O __DATA,__const	__ZTV10BaseWorker
```

Note: I reordered the output for easier comparison.

</details>

Notice how for example the `__ZN10BaseWorker7ExecuteEP10napi_env__Pv` symbol is global (`g`) in the master build, but local (`l`) in the  `-fvisibility=hidden` build. I'm guessing when two builds have global symbols with the same name (which happens on any two 5.x builds on mac), that's when conflicts like #686 arise.