### PR TITLE
Fix test-gc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "install": "node-gyp-build",
     "test": "standard && (nyc -s tape test/*-test.js | faucet) && nyc report",
-    "test-gc": "npx -n=--expose-gc tape test/{cleanup,iterator-gc,chained-batch-gc}*-test.js",
+    "test-gc": "node --expose-gc test/gc.js",
     "test-electron": "electron test/electron.js",
     "test-prebuild": "cross-env PREBUILDS_ONLY=1 npm t",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/test/gc.js
+++ b/test/gc.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// A special entry point to run certain tests with forced gc.
+
+if (!global.gc) {
+  console.error('Run with node --expose-gc')
+  process.exit(1)
+}
+
+require('./cleanup-hanging-iterators-test')
+require('./iterator-gc-test')
+require('./chained-batch-gc-test')


### PR DESCRIPTION
npx started to complain:

```
$ npm run test-gc                                                             
> npx -n=--expose-gc tape test/{cleanup,iterator-gc,chained-batch-gc}*-test.js
ERROR: --node-arg/-n can only be used on packages with node scripts.          
```