### PR TITLE
Use prebuildify-cross

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       env: [TEST=1]
     - os: linux
       node_js: node
-      env: [TEST=1, TEST_ELECTRON=1]
+      env: [TEST=1, TEST_ELECTRON=1, BUILD_GROUP=linux-x64]
       addons:
         apt:
           packages:
@@ -26,21 +26,11 @@ jobs:
       env: [TEST=1]
     - os: osx
       node_js: node
-      env: [TEST=1, TEST_ELECTRON=1, BUILD_CMD=prebuild, BUILD_GROUP=darwin-x64]
-    - name: centos7
-      os: linux
-      node_js: node
-      env: [BUILD_CMD=prebuild-centos7, BUILD_GROUP=linux-x64, NPM_CONFIG_IGNORE_SCRIPTS=1]
-      if: tag is present
+      env: [TEST=1, TEST_ELECTRON=1, BUILD_GROUP=darwin-x64]
     - name: arm
       os: linux
       node_js: node
-      env: [BUILD_CMD=prebuild-arm, BUILD_GROUP=arm, NPM_CONFIG_IGNORE_SCRIPTS=1]
-      if: tag is present
-    - name: alpine
-      os: linux
-      node_js: node
-      env: [BUILD_CMD=prebuild-alpine, BUILD_GROUP=alpine, NPM_CONFIG_IGNORE_SCRIPTS=1]
+      env: [BUILD_GROUP=arm, NPM_CONFIG_IGNORE_SCRIPTS=1]
       if: tag is present
 
 script:
@@ -52,7 +42,7 @@ after_success:
 
 before_deploy:
   - export ARCHIVE_NAME="${TRAVIS_TAG:-latest}-$BUILD_GROUP.tar.gz"
-  - NPM_CONFIG_IGNORE_SCRIPTS= npm run $BUILD_CMD
+  - NPM_CONFIG_IGNORE_SCRIPTS= npm run prebuild-$BUILD_GROUP
   - file prebuilds/*/*
   - tar -zcvf "$ARCHIVE_NAME" -C prebuilds .
 
@@ -64,7 +54,7 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: "! -z $BUILD_CMD"
+    condition: "! -z $BUILD_GROUP"
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -17,13 +17,11 @@
     "hallmark": "hallmark --fix",
     "dependency-check": "dependency-check --no-dev -i napi-macros . test/*.js",
     "prepublishOnly": "npm run dependency-check",
-    "prebuild-arm": "npm run prebuild-linux-armv7 && npm run prebuild-linux-arm64 && npm run prebuild-android-armv7 && npm run prebuild-android-arm64",
-    "prebuild-linux-armv7": "IMAGE=linux-armv7 ./scripts/cross-compile --tag-armv",
-    "prebuild-linux-arm64": "IMAGE=linux-arm64 ./scripts/cross-compile --tag-armv",
-    "prebuild-android-armv7": "IMAGE=android-armv7 ./scripts/cross-compile --tag-armv",
-    "prebuild-android-arm64": "IMAGE=android-arm64 ./scripts/cross-compile --tag-armv",
-    "prebuild-alpine": "IMAGE=alpine ./scripts/cross-compile --tag-libc",
-    "prebuild-centos7": "IMAGE=centos7-devtoolset7 ./scripts/cross-compile"
+    "prebuild-arm": "npm run prebuild-linux-arm && npm run prebuild-android-arm",
+    "prebuild-linux-arm": "prebuildify-cross -i linux-armv7 -i linux-arm64 -t 8.14.0 --napi --strip",
+    "prebuild-android-arm": "prebuildify-cross -i android-armv7 -i android-arm64 -t 8.14.0 --napi --strip",
+    "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
+    "prebuild-darwin-x64": "prebuildify -t 8.14.0 --napi --strip"
   },
   "dependencies": {
     "abstract-leveldown": "~6.2.1",
@@ -48,6 +46,7 @@
     "nyc": "^14.0.0",
     "prebuildify": "^3.0.0",
     "prebuildify-ci": "^1.0.4",
+    "prebuildify-cross": "github:prebuild/prebuildify-cross#v4.0.0",
     "readfiletree": "^1.0.0",
     "rimraf": "^3.0.0",
     "standard": "^14.0.0",

--- a/scripts/cross-compile
+++ b/scripts/cross-compile
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-DOCKER_USER="node"
-if [[ "$TRAVIS" == "true" ]]; then DOCKER_USER="travis"; fi
-
-exec docker run -u ${DOCKER_USER} --rm -v $(pwd):/app prebuild/${IMAGE} \
-     npm run prebuild -- $@


### PR DESCRIPTION
Which has been rewritten, see prebuild/prebuildify-cross#7. It's a github dependency for now; waiting for npm ownership.

In addition, CentOS & Alpine prebuilds are now built together in one Travis job. Simplifies the matrix.