### PR TITLE
Add ARMv6 prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dependency-check": "dependency-check --no-dev -i napi-macros . test/*.js",
     "prepublishOnly": "npm run dependency-check",
     "prebuild-arm": "npm run prebuild-linux-arm && npm run prebuild-android-arm",
-    "prebuild-linux-arm": "prebuildify-cross -i linux-armv7 -i linux-arm64 -t 8.14.0 --napi --strip",
+    "prebuild-linux-arm": "prebuildify-cross -i linux-armv6 -i linux-armv7 -i linux-arm64 -t 8.14.0 --napi --strip",
     "prebuild-android-arm": "prebuildify-cross -i android-armv7 -i android-arm64 -t 8.14.0 --napi --strip",
     "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
     "prebuild-darwin-x64": "prebuildify -t 8.14.0 --napi --strip"


### PR DESCRIPTION
Problem: Leveldown takes a long time to build on low-end devices like
the Pi Zero, and it would be really cool to add a prebuild for ARMv6.

Solution: I've added a Docker image in the prebuild/docker-images
repository and added ARMv6 to the prebuild-linux-arm npm script, which
I'm hoping will add the ARMv6 prebuild the next time it's run. I tried
installing via `npm install` to run the script, but ended up bumping
into some node-gyp errors that stopped me from testing this commit
locally.

Resolves #703 