### PR TITLE
Fix android arm64 prebuild by disabling exceptions

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -30,11 +30,9 @@
         "ldflags": [ "-fPIC" ],
         "cflags!": [
           "-fno-tree-vrp",
-          "-fno-exceptions",
           "-mfloat-abi=hard",
           "-fPIE"
         ],
-        "cflags_cc!": [ "-fno-exceptions" ],
         "ldflags!": [ "-fPIE" ]
       }],
       ["target_arch == 'arm'", {

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -166,19 +166,16 @@
         ],
         "ccflags": [
           "-pthread",
-          "-fno-builtin-memcmp",
-          "-fexceptions"
+          "-fno-builtin-memcmp"
         ],
         "cflags": [
           "-fPIC"
         ],
         "cflags!": [
-          "-fno-exceptions",
           "-fPIE",
           "-mfloat-abi=hard",
           "-Wno-unused-but-set-variable"
-        ],
-        "cflags_cc!": [ "-fno-exceptions" ]
+        ]
       }],
       ["target_arch == 'arm'", {
         "cflags": [


### PR DESCRIPTION
Problem: loading the android-arm64 prebuild failed with "cannot locate symbol _Unwind_Resume". Likely because that symbol does not exist (or is hidden) on some android devices. I could not positively confirm that because I could not get `gdb` or `lldb` to work in termux. Luckily we don't have to, because `_Unwind_Resume` is a function used for exceptions, which we don't need AFAICT.

Solution: disable exceptions, on both our code and leveldb code.

Closes #705.

@christianbundy, /cc @staltz as the author of #411 which enabled exceptions.