### PR TITLE
Restore Windows 32-bit prebuild

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
 configuration: Release
 platform:
   - x64
+  - x86
 
 install:
   - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%


### PR DESCRIPTION
Adds 194kb (or 406kb unpacked) to our npm package size.

Previously removed because only 2% of installs were on 32-bit Windows and we agreed those users could compile from source.

However, there is currently a gap in `electron(-builder)` tooling when used on native addons that use `node-gyp-build`: these addons don't get automatically recompiled \*. Though we don't need that anymore for runtimes (the builds are compatible with both node and electron) our users do need it when targeting multiple CPU architectures.

\* Or not _always_ recompiled, I'm not sure. I don't have enough time to investigate further.

Ref https://github.com/digidem/mapeo-desktop/issues/305
Ref https://github.com/electron-userland/electron-builder/issues/4370
Ref https://github.com/Level/leveldown/issues/554