### PR TITLE
Cirrus CI: upgrade to FreeBSD 12.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-0
+  image_family: freebsd-12-1
 
 task:
   name: FreeBSD


### PR DESCRIPTION
Has a newer OpenSSL which fixes this error: https://github.com/Level/leveldown/pull/708#issuecomment-597356507.