### PR TITLE
Vendor abstract-leveldown to reduce dependency count

### DIFF
--- a/chained-batch.js
+++ b/chained-batch.js
@@ -1,5 +1,5 @@
 const util = require('util')
-const AbstractChainedBatch = require('abstract-leveldown').AbstractChainedBatch
+const AbstractChainedBatch = require('./vendor/abstract-chained-batch')
 const binding = require('./binding')
 
 function ChainedBatch (db) {

--- a/iterator.js
+++ b/iterator.js
@@ -1,5 +1,5 @@
 const util = require('util')
-const AbstractIterator = require('abstract-leveldown').AbstractIterator
+const AbstractIterator = require('./vendor/abstract-iterator')
 const binding = require('./binding')
 
 function Iterator (db, options) {

--- a/leveldown.js
+++ b/leveldown.js
@@ -1,5 +1,5 @@
 const util = require('util')
-const AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
+const AbstractLevelDOWN = require('./vendor/abstract-leveldown')
 const binding = require('./binding')
 const ChainedBatch = require('./chained-batch')
 const Iterator = require('./iterator')

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "leveldown.js",
   "scripts": {
     "install": "node-gyp-build",
+    "vendor": "cp node_modules/abstract-leveldown/abstract-chained-batch.js ./vendor/abstract-chained-batch.js; cp node_modules/abstract-leveldown/abstract-iterator.js ./vendor/abstract-iterator.js; cp node_modules/abstract-leveldown/abstract-leveldown.js ./vendor/abstract-leveldown.js",
     "test": "standard && (nyc -s tape test/*-test.js | faucet) && nyc report",
     "test-gc": "node --expose-gc test/gc.js",
     "test-electron": "electron test/electron.js",
@@ -24,11 +25,11 @@
     "prebuild-darwin-x64": "prebuildify -t 8.14.0 --napi --strip"
   },
   "dependencies": {
-    "abstract-leveldown": "~6.2.1",
     "napi-macros": "~2.0.0",
     "node-gyp-build": "~4.1.0"
   },
   "devDependencies": {
+    "abstract-leveldown": "6.2.2",
     "async-each": "^1.0.3",
     "coveralls": "^3.0.2",
     "cross-env": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "leveldown.js",
   "scripts": {
     "install": "node-gyp-build",
-    "vendor": "cp node_modules/abstract-leveldown/abstract-chained-batch.js ./vendor/abstract-chained-batch.js; cp node_modules/abstract-leveldown/abstract-iterator.js ./vendor/abstract-iterator.js; cp node_modules/abstract-leveldown/abstract-leveldown.js ./vendor/abstract-leveldown.js",
+    "vendor": "cp node_modules/abstract-leveldown/abstract-chained-batch.js ./vendor/abstract-chained-batch.js; cp node_modules/abstract-leveldown/abstract-iterator.js ./vendor/abstract-iterator.js; cp node_modules/abstract-leveldown/abstract-leveldown.js ./vendor/abstract-leveldown.js; cp node_modules/level-supports/index.js ./vendor/level-supports.js",
     "test": "standard && (nyc -s tape test/*-test.js | faucet) && nyc report",
     "test-gc": "node --expose-gc test/gc.js",
     "test-electron": "electron test/electron.js",
@@ -42,6 +42,7 @@
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
     "level-concat-iterator": "^2.0.0",
+    "level-supports": "1.0.1",
     "mkfiletree": "^2.0.0",
     "node-gyp": "^6.0.0",
     "nyc": "^15.0.0",

--- a/vendor/abstract-chained-batch.js
+++ b/vendor/abstract-chained-batch.js
@@ -1,0 +1,81 @@
+function AbstractChainedBatch (db) {
+  if (typeof db !== 'object' || db === null) {
+    throw new TypeError('First argument must be an abstract-leveldown compliant store')
+  }
+
+  this.db = db
+  this._operations = []
+  this._written = false
+}
+
+AbstractChainedBatch.prototype._checkWritten = function () {
+  if (this._written) {
+    throw new Error('write() already called on this batch')
+  }
+}
+
+AbstractChainedBatch.prototype.put = function (key, value) {
+  this._checkWritten()
+
+  var err = this.db._checkKey(key) || this.db._checkValue(value)
+  if (err) throw err
+
+  key = this.db._serializeKey(key)
+  value = this.db._serializeValue(value)
+
+  this._put(key, value)
+
+  return this
+}
+
+AbstractChainedBatch.prototype._put = function (key, value) {
+  this._operations.push({ type: 'put', key: key, value: value })
+}
+
+AbstractChainedBatch.prototype.del = function (key) {
+  this._checkWritten()
+
+  var err = this.db._checkKey(key)
+  if (err) throw err
+
+  key = this.db._serializeKey(key)
+  this._del(key)
+
+  return this
+}
+
+AbstractChainedBatch.prototype._del = function (key) {
+  this._operations.push({ type: 'del', key: key })
+}
+
+AbstractChainedBatch.prototype.clear = function () {
+  this._checkWritten()
+  this._clear()
+
+  return this
+}
+
+AbstractChainedBatch.prototype._clear = function () {
+  this._operations = []
+}
+
+AbstractChainedBatch.prototype.write = function (options, callback) {
+  this._checkWritten()
+
+  if (typeof options === 'function') { callback = options }
+  if (typeof callback !== 'function') {
+    throw new Error('write() requires a callback argument')
+  }
+  if (typeof options !== 'object' || options === null) {
+    options = {}
+  }
+
+  this._written = true
+  this._write(options, callback)
+}
+
+AbstractChainedBatch.prototype._write = function (options, callback) {
+  this.db._batch(this._operations, options, callback)
+}
+
+module.exports = AbstractChainedBatch

--- a/vendor/abstract-iterator.js
+++ b/vendor/abstract-iterator.js
@@ -1,0 +1,72 @@
+function AbstractIterator (db) {
+  if (typeof db !== 'object' || db === null) {
+    throw new TypeError('First argument must be an abstract-leveldown compliant store')
+  }
+
+  this.db = db
+  this._ended = false
+  this._nexting = false
+}
+
+AbstractIterator.prototype.next = function (callback) {
+  var self = this
+
+  if (typeof callback !== 'function') {
+    throw new Error('next() requires a callback argument')
+  }
+
+  if (self._ended) {
+    process.nextTick(callback, new Error('cannot call next() after end()'))
+    return self
+  }
+
+  if (self._nexting) {
+    process.nextTick(callback, new Error('cannot call next() before previous next() has completed'))
+    return self
+  }
+
+  self._nexting = true
+  self._next(function () {
+    self._nexting = false
+    callback.apply(null, arguments)
+  })
+
+  return self
+}
+
+AbstractIterator.prototype._next = function (callback) {
+  process.nextTick(callback)
+}
+
+AbstractIterator.prototype.seek = function (target) {
+  if (this._ended) {
+    throw new Error('cannot call seek() after end()')
+  }
+  if (this._nexting) {
+    throw new Error('cannot call seek() before next() has completed')
+  }
+
+  target = this.db._serializeKey(target)
+  this._seek(target)
+}
+
+AbstractIterator.prototype._seek = function (target) {}
+
+AbstractIterator.prototype.end = function (callback) {
+  if (typeof callback !== 'function') {
+    throw new Error('end() requires a callback argument')
+  }
+
+  if (this._ended) {
+    return process.nextTick(callback, new Error('end() already called on iterator'))
+  }
+
+  this._ended = true
+  this._end(callback)
+}
+
+AbstractIterator.prototype._end = function (callback) {
+  process.nextTick(callback)
+}
+
+module.exports = AbstractIterator

--- a/vendor/abstract-leveldown.js
+++ b/vendor/abstract-leveldown.js
@@ -1,0 +1,315 @@
+var xtend = require('xtend')
+var supports = require('level-supports')
+var AbstractIterator = require('./abstract-iterator')
+var AbstractChainedBatch = require('./abstract-chained-batch')
+var hasOwnProperty = Object.prototype.hasOwnProperty
+var rangeOptions = 'start end gt gte lt lte'.split(' ')
+
+function AbstractLevelDOWN (manifest) {
+  this.status = 'new'
+
+  // TODO (next major): make this mandatory
+  this.supports = supports(manifest, {
+    status: true
+  })
+}
+
+AbstractLevelDOWN.prototype.open = function (options, callback) {
+  var self = this
+  var oldStatus = this.status
+
+  if (typeof options === 'function') callback = options
+
+  if (typeof callback !== 'function') {
+    throw new Error('open() requires a callback argument')
+  }
+
+  if (typeof options !== 'object' || options === null) options = {}
+
+  options.createIfMissing = options.createIfMissing !== false
+  options.errorIfExists = !!options.errorIfExists
+
+  this.status = 'opening'
+  this._open(options, function (err) {
+    if (err) {
+      self.status = oldStatus
+      return callback(err)
+    }
+    self.status = 'open'
+    callback()
+  })
+}
+
+AbstractLevelDOWN.prototype._open = function (options, callback) {
+  process.nextTick(callback)
+}
+
+AbstractLevelDOWN.prototype.close = function (callback) {
+  var self = this
+  var oldStatus = this.status
+
+  if (typeof callback !== 'function') {
+    throw new Error('close() requires a callback argument')
+  }
+
+  this.status = 'closing'
+  this._close(function (err) {
+    if (err) {
+      self.status = oldStatus
+      return callback(err)
+    }
+    self.status = 'closed'
+    callback()
+  })
+}
+
+AbstractLevelDOWN.prototype._close = function (callback) {
+  process.nextTick(callback)
+}
+
+AbstractLevelDOWN.prototype.get = function (key, options, callback) {
+  if (typeof options === 'function') callback = options
+
+  if (typeof callback !== 'function') {
+    throw new Error('get() requires a callback argument')
+  }
+
+  var err = this._checkKey(key)
+  if (err) return process.nextTick(callback, err)
+
+  key = this._serializeKey(key)
+
+  if (typeof options !== 'object' || options === null) options = {}
+
+  options.asBuffer = options.asBuffer !== false
+
+  this._get(key, options, callback)
+}
+
+AbstractLevelDOWN.prototype._get = function (key, options, callback) {
+  process.nextTick(function () { callback(new Error('NotFound')) })
+}
+
+AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
+  if (typeof options === 'function') callback = options
+
+  if (typeof callback !== 'function') {
+    throw new Error('put() requires a callback argument')
+  }
+
+  var err = this._checkKey(key) || this._checkValue(value)
+  if (err) return process.nextTick(callback, err)
+
+  key = this._serializeKey(key)
+  value = this._serializeValue(value)
+
+  if (typeof options !== 'object' || options === null) options = {}
+
+  this._put(key, value, options, callback)
+}
+
+AbstractLevelDOWN.prototype._put = function (key, value, options, callback) {
+  process.nextTick(callback)
+}
+
+AbstractLevelDOWN.prototype.del = function (key, options, callback) {
+  if (typeof options === 'function') callback = options
+
+  if (typeof callback !== 'function') {
+    throw new Error('del() requires a callback argument')
+  }
+
+  var err = this._checkKey(key)
+  if (err) return process.nextTick(callback, err)
+
+  key = this._serializeKey(key)
+
+  if (typeof options !== 'object' || options === null) options = {}
+
+  this._del(key, options, callback)
+}
+
+AbstractLevelDOWN.prototype._del = function (key, options, callback) {
+  process.nextTick(callback)
+}
+
+AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
+  if (!arguments.length) return this._chainedBatch()
+
+  if (typeof options === 'function') callback = options
+
+  if (typeof array === 'function') callback = array
+
+  if (typeof callback !== 'function') {
+    throw new Error('batch(array) requires a callback argument')
+  }
+
+  if (!Array.isArray(array)) {
+    return process.nextTick(callback, new Error('batch(array) requires an array argument'))
+  }
+
+  if (array.length === 0) {
+    return process.nextTick(callback)
+  }
+
+  if (typeof options !== 'object' || options === null) options = {}
+
+  var serialized = new Array(array.length)
+
+  for (var i = 0; i < array.length; i++) {
+    if (typeof array[i] !== 'object' || array[i] === null) {
+      return process.nextTick(callback, new Error('batch(array) element must be an object and not `null`'))
+    }
+
+    var e = xtend(array[i])
+
+    if (e.type !== 'put' && e.type !== 'del') {
+      return process.nextTick(callback, new Error("`type` must be 'put' or 'del'"))
+    }
+
+    var err = this._checkKey(e.key)
+    if (err) return process.nextTick(callback, err)
+
+    e.key = this._serializeKey(e.key)
+
+    if (e.type === 'put') {
+      var valueErr = this._checkValue(e.value)
+      if (valueErr) return process.nextTick(callback, valueErr)
+
+      e.value = this._serializeValue(e.value)
+    }
+
+    serialized[i] = e
+  }
+
+  this._batch(serialized, options, callback)
+}
+
+AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
+  process.nextTick(callback)
+}
+
+AbstractLevelDOWN.prototype.clear = function (options, callback) {
+  if (typeof options === 'function') {
+    callback = options
+  } else if (typeof callback !== 'function') {
+    throw new Error('clear() requires a callback argument')
+  }
+
+  options = cleanRangeOptions(this, options)
+  options.reverse = !!options.reverse
+  options.limit = 'limit' in options ? options.limit : -1
+
+  this._clear(options, callback)
+}
+
+AbstractLevelDOWN.prototype._clear = function (options, callback) {
+  // Avoid setupIteratorOptions, would serialize range options a second time.
+  options.keys = true
+  options.values = false
+  options.keyAsBuffer = true
+  options.valueAsBuffer = true
+
+  var iterator = this._iterator(options)
+  var emptyOptions = {}
+  var self = this
+
+  var next = function (err) {
+    if (err) {
+      return iterator.end(function () {
+        callback(err)
+      })
+    }
+
+    iterator.next(function (err, key) {
+      if (err) return next(err)
+      if (key === undefined) return iterator.end(callback)
+
+      // This could be optimized by using a batch, but the default _clear
+      // is not meant to be fast. Implementations have more room to optimize
+      // if they override _clear. Note: using _del bypasses key serialization.
+      self._del(key, emptyOptions, next)
+    })
+  }
+
+  next()
+}
+
+AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
+  options = cleanRangeOptions(this, options)
+
+  options.reverse = !!options.reverse
+  options.keys = options.keys !== false
+  options.values = options.values !== false
+  options.limit = 'limit' in options ? options.limit : -1
+  options.keyAsBuffer = options.keyAsBuffer !== false
+  options.valueAsBuffer = options.valueAsBuffer !== false
+
+  return options
+}
+
+function cleanRangeOptions (db, options) {
+  var result = {}
+
+  for (var k in options) {
+    if (!hasOwnProperty.call(options, k)) continue
+
+    var opt = options[k]
+
+    if (isRangeOption(k)) {
+      // Note that we don't reject nullish and empty options here. While
+      // those types are invalid as keys, they are valid as range options.
+      opt = db._serializeKey(opt)
+    }
+
+    result[k] = opt
+  }
+
+  return result
+}
+
+function isRangeOption (k) {
+  return rangeOptions.indexOf(k) !== -1
+}
+
+AbstractLevelDOWN.prototype.iterator = function (options) {
+  if (typeof options !== 'object' || options === null) options = {}
+  options = this._setupIteratorOptions(options)
+  return this._iterator(options)
+}
+
+AbstractLevelDOWN.prototype._iterator = function (options) {
+  return new AbstractIterator(this)
+}
+
+AbstractLevelDOWN.prototype._chainedBatch = function () {
+  return new AbstractChainedBatch(this)
+}
+
+AbstractLevelDOWN.prototype._serializeKey = function (key) {
+  return key
+}
+
+AbstractLevelDOWN.prototype._serializeValue = function (value) {
+  return value
+}
+
+AbstractLevelDOWN.prototype._checkKey = function (key) {
+  if (key === null || key === undefined) {
+    return new Error('key cannot be `null` or `undefined`')
+  } else if (Buffer.isBuffer(key) && key.length === 0) {
+    return new Error('key cannot be an empty Buffer')
+  } else if (key === '') {
+    return new Error('key cannot be an empty String')
+  } else if (Array.isArray(key) && key.length === 0) {
+    return new Error('key cannot be an empty Array')
+  }
+}
+
+AbstractLevelDOWN.prototype._checkValue = function (value) {
+  if (value === null || value === undefined) {
+    return new Error('value cannot be `null` or `undefined`')
+  }
+}
+
+module.exports = AbstractLevelDOWN

--- a/vendor/abstract-leveldown.js
+++ b/vendor/abstract-leveldown.js
@@ -1,5 +1,4 @@
-var xtend = require('xtend')
-var supports = require('level-supports')
+var supports = require('./level-supports')
 var AbstractIterator = require('./abstract-iterator')
 var AbstractChainedBatch = require('./abstract-chained-batch')
 var hasOwnProperty = Object.prototype.hasOwnProperty
@@ -161,7 +160,7 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
       return process.nextTick(callback, new Error('batch(array) element must be an object and not `null`'))
     }
 
-    var e = xtend(array[i])
+    var e = Object.assign({}, array[i])
 
     if (e.type !== 'put' && e.type !== 'del') {
       return process.nextTick(callback, new Error("`type` must be 'put' or 'del'"))

--- a/vendor/level-supports.js
+++ b/vendor/level-supports.js
@@ -1,0 +1,35 @@
+'use strict'
+
+// For (old) browser support
+var xtend = require('xtend')
+var assign = require('xtend/mutable')
+
+module.exports = function supports () {
+  var manifest = xtend.apply(null, arguments)
+
+  return assign(manifest, {
+    // Features of abstract-leveldown
+    bufferKeys: manifest.bufferKeys || false,
+    snapshots: manifest.snapshots || false,
+    permanence: manifest.permanence || false,
+    seek: manifest.seek || false,
+    clear: manifest.clear || false,
+
+    // Features of abstract-leveldown that levelup doesn't have
+    status: manifest.status || false,
+
+    // Features of disk-based implementations
+    createIfMissing: manifest.createIfMissing || false,
+    errorIfExists: manifest.errorIfExists || false,
+
+    // Features of level(up) that abstract-leveldown doesn't have yet
+    deferredOpen: manifest.deferredOpen || false,
+    openCallback: manifest.openCallback || false,
+    promises: manifest.promises || false,
+    streams: manifest.streams || false,
+    encodings: manifest.encodings || false,
+
+    // Methods that are not part of abstract-leveldown or levelup
+    additionalMethods: xtend(manifest.additionalMethods)
+  })
+}

--- a/vendor/level-supports.js
+++ b/vendor/level-supports.js
@@ -29,6 +29,6 @@ module.exports = function supports () {
     encodings: manifest.encodings || false,
 
     // Methods that are not part of abstract-leveldown or levelup
-    additionalMethods: xtend(manifest.additionalMethods)
+    additionalMethods: Object.assign({}, manifest.additionalMethods)
   })
 }

--- a/vendor/level-supports.js
+++ b/vendor/level-supports.js
@@ -1,13 +1,12 @@
 'use strict'
 
-// For (old) browser support
-var xtend = require('xtend')
-var assign = require('xtend/mutable')
-
 module.exports = function supports () {
-  var manifest = xtend.apply(null, arguments)
+  var manifest = {}
+  for (let i = 0; i < arguments.length; i++) {
+    Object.assign(manifest, arguments[i])
+  }
 
-  return assign(manifest, {
+  return Object.assign(manifest, {
     // Features of abstract-leveldown
     bufferKeys: manifest.bufferKeys || false,
     snapshots: manifest.snapshots || false,


### PR DESCRIPTION
I recently read about how the `is-promise` module broke
a bunch of code and it reminds me that I need to audit
all my dependencies for unnecessary code & modules.

I've been working on making `level` & `level-packager`
lighterweight. I've gotten an alternative lighterweight
module for `levelup` written but `leveldown` and
`abstract-leveldown` are still there are non-trivial
dependencies.

A recent version of `abstract-leveldown` increased
the dependency count by adding `immediate`, `buffer`,
`base64-js` & `ieee754`.

`leveldown` itself has two critical dependencies,
`napi-macros` & `node-gyp-build` for compiling C++.
These are reasonable dependencies.

I've opted for vendoring the implementation of
`abstract-leveldown` and moving `abstract-leveldown`
to a dev dependencies.

This allows for a couple of changes I've made in the
`vendor` directory to remove browser support and to
also inline `level-supports` and remove `xtend`.

This change re-uses all the `abstract-leveldown` code
and reduces the dependency count for `leveldown` from
3 direct deps & 8 indirect deps to only having 2 direct
deps.

That's a reduction from leveldown + 11 to leveldown + 2

cc @vweevers