### PR TITLE
IBM System Z (s390x architecture) support for deps/level-db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       os: linux
       arch: s390x
       node_js: 10
-      env: [TEST=1, BUILD_GROUP=s390x]
+      env: [TEST=1, BUILD_GROUP=s390x, ELECTRON_SKIP_BINARY_DOWNLOAD=1]
 
 script:
   - if [[ ! -z "$TEST" ]]; then npm run test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ jobs:
       node_js: node
       env: [BUILD_GROUP=arm, NPM_CONFIG_IGNORE_SCRIPTS=1]
       if: tag is present
+    - name: s390x
+      os: linux
+      node_js: 10
+      env: [TEST=1, BUILD_GROUP=s390x]
 
 script:
   - if [[ ! -z "$TEST" ]]; then npm run test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       if: tag is present
     - name: s390x
       os: linux
+      arch: s390x
       node_js: 10
       env: [TEST=1, BUILD_GROUP=s390x]
 

--- a/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
+++ b/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
@@ -41,6 +41,8 @@
 #define ARCH_CPU_PPC_FAMILY 1
 #elif defined(__mips__)
 #define ARCH_CPU_MIPS_FAMILY 1
+#elif defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+#define ARCH_CPU_S390X_FAMILY 1
 #endif
 
 namespace leveldb {
@@ -119,6 +121,13 @@ inline void MemoryBarrier() {
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 
+
+// S390X Linux
+#elif defined(ARCH_CPU_S390X_FAMILY)
+inline void MemoryBarrier() {  
+	__asm__ __volatile__("sync" : : : "memory");
+}
+#define LEVELDB_HAVE_MEMORY_BARRIER
 #endif
 
 // AtomicPointer built using platform-specific MemoryBarrier()
@@ -226,8 +235,7 @@ class AtomicPointer {
 
 // We have neither MemoryBarrier(), nor <atomic>
 #else
-#error Please implement AtomicPointer for this platform.
-
+#error Please implement AtomicPointer for this platformmmmmmmmm. 
 #endif
 
 #undef LEVELDB_HAVE_MEMORY_BARRIER

--- a/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
+++ b/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
@@ -125,7 +125,7 @@ inline void MemoryBarrier() {
 // S390X Linux
 #elif defined(ARCH_CPU_S390X_FAMILY)
 inline void MemoryBarrier() {  
-	__asm__ __volatile__("sync" : : : "memory");
+	__asm__ __volatile__("" : : : "memory");
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 #endif


### PR DESCRIPTION
This allows IBM System Z (s390x) to build the `leveldown` during the `npm install`. 