### PR TITLE
Upgrade FreeBSD in CI from 12.1 to 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 freebsd_instance:
-  image_family: freebsd-12-1
+  image_family: freebsd-12-2
 
 task:
   name: FreeBSD
   provision_script:
-    - pkg install -y git libnghttp2 node npm
+    - pkg install -y git node npm
   install_script:
     - git submodule update --init --recursive
     - env ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm i --unsafe-perm


### PR DESCRIPTION
To hopefully fix the error seen in #759 (which I can't reproduce locally in 12.2):

```
> leveldown@5.6.0 install /tmp/cirrus-ci-build
> node-gyp-build

ld-elf.so.1: /usr/local/lib/libpython3.7m.so.1.0: Undefined symbol "close_range@FBSD_1.6"
gyp: Call to 'node -e "require('napi-macros')"' returned exit status 1 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/tmp/cirrus-ci-build/node_modules/node-gyp/lib/configure.js:351:16)
gyp ERR! stack     at ChildProcess.emit (node:events:378:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
gyp ERR! System FreeBSD 12.1-RELEASE
```