### PR TITLE
Build a universal binary to support M1 (Apple silicon)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,10 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             build-group: android-arm
-          - os: macos-latest
+          # At the time of writing macos-latest is mac 10; we need 11 to build a universal binary.
+          - os: macos-11
             arch: x64
-            build-group: darwin-x64
+            build-group: darwin-x64+arm64
           - os: windows-latest
             arch: x86
             build-group: win32-x86

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,13 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # At the time of writing macos-latest is mac 10; we need 11 to build a universal binary.
+        os: [ubuntu-latest, macos-11, windows-latest]
         node: [10, 12, 14]
         arch: [x86, x64]
         exclude:
           - { os: ubuntu-latest, arch: x86 }
-          - { os: macos-latest, arch: x86 }
+          - { os: macos-11, arch: x86 }
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Node ${{ matrix.node }} ${{ matrix.arch }}
     steps:

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ See the section on <a href="#safety">safety</a> below for details of known unsaf
 
 We aim to support _at least_ Active LTS and Current Node.js releases, Electron 5.0.0, as well as any future Node.js and Electron releases thanks to [N-API](https://nodejs.org/api/n-api.html). The minimum node version for `leveldown` is `10.12.0`. Conversely, for node >= 12, the minimum `leveldown` version is `5.0.0`.
 
-The `leveldown` npm package ships with prebuilt binaries for popular 64-bit platforms as well as ARM, Android and Alpine (musl) and is known to work on:
+The `leveldown` npm package ships with prebuilt binaries for popular 64-bit platforms as well as ARM, M1, Android and Alpine (musl) and is known to work on:
 
 - **Linux** (including ARM platforms such as Raspberry Pi and Kindle)
-- **Mac OS**
+- **Mac OS** (10.7 and later)
 - **Solaris** (SmartOS & Nodejitsu)
 - **FreeBSD**
 - **Windows**

--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,22 @@
       ["OS == 'mac'", {
         "cflags+": ["-fvisibility=hidden"],
         "xcode_settings": {
-          "GCC_SYMBOLS_PRIVATE_EXTERN": "YES" # -fvisibility=hidden
+          # -fvisibility=hidden
+          "GCC_SYMBOLS_PRIVATE_EXTERN": "YES",
+
+          # Set minimum target version because we're building on newer
+          # Same as https://github.com/nodejs/node/blob/v10.0.0/common.gypi#L416
+          "MACOSX_DEPLOYMENT_TARGET": "10.7",
+
+          # Build universal binary to support M1 (Apple silicon)
+          "OTHER_CFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
+          ],
+          "OTHER_LDFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
+          ]
         }
       }],
       ["OS == 'android'", {

--- a/deps/leveldb/leveldb.gyp
+++ b/deps/leveldb/leveldb.gyp
@@ -153,6 +153,15 @@
             "-Wno-sign-compare",
             "-Wno-unused-variable",
             "-Wno-unused-function"
+          ],
+
+          # Set minimum target version because we're building on newer
+          "MACOSX_DEPLOYMENT_TARGET": "10.7",
+
+          # Build universal binary to support M1 (Apple silicon)
+          "OTHER_CFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
           ]
         }
       }],

--- a/deps/snappy/snappy.gyp
+++ b/deps/snappy/snappy.gyp
@@ -72,6 +72,15 @@
           "WARNING_CFLAGS": [
             "-Wno-sign-compare",
             "-Wno-unused-function"
+          ],
+
+          # Set minimum target version because we're building on newer
+          "MACOSX_DEPLOYMENT_TARGET": "10.7",
+
+          # Build universal binary to support M1 (Apple silicon)
+          "OTHER_CFLAGS": [
+            "-arch x86_64",
+            "-arch arm64"
           ]
         }
       }],

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "prebuild-linux-arm": "prebuildify-cross -i linux-armv6 -i linux-armv7 -i linux-arm64 -t 8.14.0 --napi --strip",
     "prebuild-android-arm": "prebuildify-cross -i android-armv7 -i android-arm64 -t 8.14.0 --napi --strip",
     "prebuild-linux-x64": "prebuildify-cross -i centos7-devtoolset7 -i alpine -t 8.14.0 --napi --strip",
-    "prebuild-darwin-x64": "prebuildify -t 8.14.0 --napi --strip",
+    "prebuild-darwin-x64+arm64": "prebuildify -t 8.14.0 --napi --strip --arch x64+arm64",
     "prebuild-win32-x86": "prebuildify -t 8.14.0 --napi --strip",
     "prebuild-win32-x64": "prebuildify -t 8.14.0 --napi --strip"
   },
   "dependencies": {
     "abstract-leveldown": "^7.0.0",
     "napi-macros": "~2.0.0",
-    "node-gyp-build": "~4.2.1"
+    "node-gyp-build": "^4.3.0"
   },
   "devDependencies": {
     "async-each": "^1.0.3",
@@ -43,7 +43,7 @@
     "mkfiletree": "^2.0.0",
     "node-gyp": "^7.1.2",
     "nyc": "^15.0.0",
-    "prebuildify": "^4.1.0",
+    "prebuildify": "^4.2.1",
     "prebuildify-ci": "^1.0.4",
     "prebuildify-cross": "^4.0.1",
     "readfiletree": "^1.0.0",


### PR DESCRIPTION
Closes #766. Depends on https://github.com/prebuild/prebuildify/pull/53 and https://github.com/prebuild/node-gyp-build/pull/40.