### PR TITLE
style: fix new `standard` linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prebuildify-cross": "^4.0.1",
     "readfiletree": "^1.0.0",
     "rimraf": "^3.0.0",
-    "standard": "^16.0.3",
+    "standard": "^17.0.0-2",
     "tape": "^5.0.1",
     "tempy": "^1.0.1"
   },

--- a/test/common.js
+++ b/test/common.js
@@ -4,7 +4,7 @@ const leveldown = require('..')
 const suite = require('abstract-leveldown/test')
 
 module.exports = suite.common({
-  test: test,
+  test,
   factory: function () {
     return leveldown(tempy.directory())
   },

--- a/test/compression-test.js
+++ b/test/compression-test.js
@@ -30,7 +30,7 @@ const cycle = function (db, compression, t, callback) {
   db.close(function (err) {
     t.error(err)
     db = leveldown(location)
-    db.open({ errorIfExists: false, compression: compression }, function () {
+    db.open({ errorIfExists: false, compression }, function () {
       t.error(err)
       db.close(function (err) {
         t.error(err)

--- a/test/leak-tester-batch.js
+++ b/test/leak-tester-batch.js
@@ -25,24 +25,24 @@ function print () {
 
 const run = CHAINED
   ? function () {
-      const batch = db.batch()
+    const batch = db.batch()
 
-      for (let i = 0; i < 100; i++) {
-        let key = 'long key to test memory usage ' + String(Math.floor(Math.random() * 10000000))
-        if (BUFFERS) key = Buffer.from(key)
-        let value = crypto.randomBytes(1024)
-        if (!BUFFERS) value = value.toString('hex')
-        batch.put(key, value)
-      }
-
-      batch.write(function (err) {
-        assert(!err)
-        process.nextTick(run)
-      })
-
-      writeCount++
-      print()
+    for (let i = 0; i < 100; i++) {
+      let key = 'long key to test memory usage ' + String(Math.floor(Math.random() * 10000000))
+      if (BUFFERS) key = Buffer.from(key)
+      let value = crypto.randomBytes(1024)
+      if (!BUFFERS) value = value.toString('hex')
+      batch.put(key, value)
     }
+
+    batch.write(function (err) {
+      assert(!err)
+      process.nextTick(run)
+    })
+
+    writeCount++
+    print()
+  }
   : function () {
     const batch = []
 
@@ -51,7 +51,7 @@ const run = CHAINED
       if (BUFFERS) key = Buffer.from(key)
       let value = crypto.randomBytes(1024)
       if (!BUFFERS) value = value.toString('hex')
-      batch.push({ type: 'put', key: key, value: value })
+      batch.push({ type: 'put', key, value })
     }
 
     db.batch(batch, function (err) {


### PR DESCRIPTION
This PR update `standard` to the next version (v17) coming soon and fixes linting issues (using `standard --fix`).
This allows having the `test-external` of `standard` passing for `level/leveldown`, before releasing to stable, we ensure that the ecosystem can easily upgrade without issues.

Related: https://github.com/standard/standard/issues/1777

This new version includes:
- [`object-shorthand` rule](https://github.com/standard/eslint-config-standard/pull/166) (as warning)
- Support for ESLint v8
- `--verbose` by default